### PR TITLE
Automatic BGM information updating

### DIFF
--- a/Data/xiv_bgm.csv
+++ b/Data/xiv_bgm.csv
@@ -1,812 +1,808 @@
-ID;Name;Locations;Color by Expansion/Collab
-0;Default;your Current BGM playing;
-1;N/A;N/A;
-2;Prelude ~ Rebirth;Start-up (ARR);Intro/Title music
-3;Dreams Aloft;1.0/Old launcher theme;Heroic-ish music is in game
-4;Prelude ~ Discoveries;Character Select;Character Creation
-5;Behind Closed Doors;Inn;
-6;Wailers and Waterwheels;Gridania;Daytime Theme
-7;Dance of the Fireflies;Gridania;Nighttime Theme
-8;Serenity;Central/North Shroud;Intro/Daybreak
-9;Serenity;Black Shroud settlements;
-10;Serenity;The Black Shroud;
-11;Serenity;South Shroud;
-12;Serenity;Sanctum of the Twelve;
-13;The Land Bends;The Black Shroud;Gridania Combat BGM
-14;Tenacity;Any Leve Locations;Repeated BGM during Leve
-15;Slumber Disturbed;The Tam-Tara Deepcroft;
-16;The Promise of Plunder;Early ARR Dungeons;
-17;The Dark's Embrace*;ARR HM Dungeons;Transitions "The Dark's Kiss" combat
-18;A Victory Fanfare Reborn;Any Locations;
-19;N/A;N/A;
-20;Victory! NoVocals;N/A;
-21;Victory!;N/A;
-22;Frontline Battle Start;PvP Maps;
-23;The Hero of Hatchingtide;Various;Chiptune Victory
-24;Greenwrath;East Shroud;
-25;I Am the Sea;Limsa Lominsa;Daytime Theme
-26;A Sailor Never Sleeps;Limsa Lominsa;NightTime Theme
-27;On Westerly Winds;Middle/Lower La Noscea;Intro/Daybreak
-28;On Westerly Winds;La Noscea;
-29;On Westerly Winds;Eastern La Noscea;
-30;On Westerly Winds;Eastern La Noscea;
-31;On Westerly Winds;La Noscean settlements;
-32;Currents;La Noscea;
-33;The Land Breathes;La Noscea;La Noscea Combat BGM
-34;N/A;N/A;
-35;From the Depths;Sastasha;
-36;Torn from the heavens;Various;
-37;A Fine Death;Dungeon bosses;
-38;Nemesis;ARR Dungeon bosses;
-39;Pennons Aloft;Instanced battles;
-40;Brothers in Arms;Guildhests;
-41;The Maiden's Lament;Haukke Manor;
-42;A Thousand Screams;The Thousand Maws of Toto-Rak;
-43;Lipflaps on Longstops;Brayflox's Longstop;
-44;A New Hope;Ul'dah;Daytime Theme
-45;Sultana Dreaming;Ul'dah;Nighttime Theme
-46;To the Sun;Western/Central Thanalan;Intro/Daybreak
-47;To the Sun;Thanalan;
-48;To the Sun;Southern Thanalan;
-49;To the Sun;Thanalan settlements;
-50;To the Sun;Thanalan;
-51;Fleeting Rays;Eastern Thanalan;
-52;The Land Burns;Thanalan;Thanalan Combat BGM
-53;Below;Copperbell Mines;
-54;The Ludus;Halatali;
-55;The Gift of Life;;
-56;Calling;;
-57;Discordance;Northern Thanalan;
-58;Beyond the Unknown;review;Very short
-59;Slither;Mysterious locations;Very short
-60;Intertwined;Mor Dhona;
-61;Bo-down;Chocobo porters;
-62;Eorzea de Chocobo;Chocobo mounts;
-63;Into the Adder's Den;New Gridania;The Order of the Twin Adder
-64;Maelstrom Command;Upper Limsa Lominsa;The Maelstrom
-65;The Hall of Flames;Ul'dah - Steps of Nald;The Immortal Flames
-66;The Waking Sands;Western Thanalan;The Scion HQ
-67;When a Tree Falls;Gathering leves;
-68;The Tug of Fate;Certain FATEs;
-69;To the Fore;Certain FATEs/Boss battles;
-70;Whisper of the Land ;Cutscenes (1.0);
-71;On Windy Meadows;Cutscenes (1.0);
-72;Twilight Over Thanalan;Cutscenes (1.0);
-73;Dewdrops & Moonbeams;The Lotus Stand (Kan-E-Senna);
-74;The Sands' Secrets;Eorzean Alliance (Raubahn);
-75;Ripples in the Sea;Eorzean Alliance (Merlwyb);
-76;Imperial Will;Empire Cutscenes;
-77;Defender of the Realm;Cutscenes (Heroic);
-78;Fracture;Cutscenes (Suspense);
-79;One Blood;Cutscenes (Tension);
-80;Conundrum;Cutscenes (Mysterious/Hildibrand);
-81;Prelude ~ Rebirth (Edit);Cutscenes;
-82;Return of the Hero;Cutscenes (Resolution);
-83;Kiss of Chaos;Cutscenes (Tension);
-84;Forever Lost;Cutscenes (Sad);
-85;Machinations;Wolves' Den;
-86;The Only Path;Cutscenes (Positive);
-87;Daring Dalliances;Cutscenes (Positive);
-88;Bliss;Cutscenes (Comedic);
-89;A World Apart;Cutscenes (Heroic);
-90;Relics;Cutscenes (esp. Job quests);
-91;Breaking Boundaries;Job quest battles;
-92;The Echo;The Echo cutscenes;
-93;Tranquility;Cutscenes (Resolution);
-94;Without Shadow;Ascian Cutscenes;
-95;The Seventh Sun;Cutscenes;
-96;Sacred Bonds;Cutscenes (Sad);
-97;Canticle;Cutscenes (Exposition);
-98;Where the Heart Is (1.0);Cutscenes (Resolution);
-99;Dreams Aloft;Cutscenes (Resolution);
-100;Supply & Demand;Cutscenes (Comedic);1.0 track
-101;By Design;Cutscenes (Comedic);1.0 track
-102;Decisions;Cutscenes (Mysterious);1.0 track
-103;Agent of Inquiry;Hildibrand Theme;
-104;;;
-105;Nature's Bounty;Cutscenes, Eternal Bonding;1.0 track
-106;Prelude;Various, Eternal Bonding;
-107;Pennons Aloft;Instanced battles, Fenrir battle;1.0 track
-108;Battle Theme 1.x;Hildibrand FATEs/Hall of the Novice;
-109;;;
-110;Salt Swept;Aleport/Moraby Drydocks;
-111;Paris Themed;Limsa Lominsa;
-112;My Soul to Keep;Haukke Manor/Tam-Tara HM;
-113;From Fear to Fortitude;Instanced battles;
-114;Damnation;Cutscenes (Suspense);
-115;Hard to Miss;Boss FATEs;
-116;A Fell Air Falleth;Later ARR Dungeons;
-117;Skullduggery;Instanced battles/Qarn HM;
-118;Another Round;Bars and Taverns;
-119;Ruby Sunrise;Costa del Sol;
-120;Primal Judgement ;The Bowl of Embers;
-121;The Rider's Boon;ARR mounts;
-122;Cracks in the Wall;Amdapor Keep;
-123;A Tonberry's Tears;The Wanderer's Palace;
-124;Echoes of Ages Past;The Sunken Temple of Qarn;
-125;Abomination;Cutter's Cry;
-126;Cold Salvation;The Stone Vigil;
-127;The Darkhold;Dzemael Darkhold;
-128;Miser's Folly;The Aurum Vale;
-129;Engage;Enterprise Cutscenes (Diadem);
-130;Fever Dream;Cutscenes (Tension);Excerpt from a longer 1.0 track
-131;Serving the Light;Warrior of Light;
-132;Answers;ARR End Credits;
-133;Opening Theme;ARR End Credits Special/1.0 players;1.0 ending
-134;A Curious Breed of Botherment;Sylph Theme song;
-135;Flightless Wings;Ixal Theme song;
-136;Quick as Silver, Hard as Stone;Kobold theme song;
-137;Battle Drums ;Sahagin theme song;1.0 track
-138;Pitfire;Amalj'aa theme song;1.0 track
-139;Beast Alliance;Beast Tribe Alliance;
-140;One Eyed Mercernary;Beast Tribe Rival;
-141;Fealty;Coerthas Central Highlands;
-142;The Dragon's Dirge;Ishgard;
-143;Undying Faith;Ishgard;
-144;The Land Breaks;Coerthas Central Highlands;Coerthas Combat BGM
-145;The Land Bleeds;Mor Dhona;Mor Dhona Combat BGM
-146;Primal Timbre*;The Binding Coil of Bahamut;Transitions into "Spiral" in combat
-147;Calamity Unbound;The Binding Coil of Bahamut (Bosses);
-148;The Emperor's Wont;Imperial Castrums;
-149;Penitus;The Praetorium;
-150;Ultima;Ultima Weapon Phase 2;
-151;Steel Reason;Cape Westwind/Garlean boss fights;
-152;Bite of the Black Wolf;Gaius van Baelsar theme;
-153;The Corpse Hall;Odin FATE;
-154;Thunderer;Various battles;
-155;Fallen Angel;The Howling Eye;
-156;Under the Weight;Titan Phase 4;
-157;Weight of a Whisper;Titan Phase 1;
-158;Weight of His Will ;Titan Phase 2;
-159;Weight of the World;Titan Phase 3;
-160;Heartless;Titan's Heart phase;
-161;Flight;Ultima escape music?;
-162;The Maker's Ruin;Ultima Weapon Phase 1;
-163;Blinded by light (FFXIII);;
-164;More FFXIII music;;
-165;Torn From The Heavens;;1.0 Track
-166;Ruby Moonrise;Costa del Sol events;Fast "Costa Del Sol" music
-167;Serenity (short);The Shroud;
-168;On Westerly Winds (short);La Noscea;
-169;To the Sun (short);Thanalan;
-170;Crystal Rain (short);Mor Dhona;
-171;To the Fore;;
-172;The Rider's Boon;Default 1.0 mount theme/Generic;
-173;Thunderer;(Twintania/Ascian Boss Theme);
-174;All Saint's Wake;Event;
-175;Starlight Celebration;Event;
-176;Heavensturn;Event;
-177;Reign of Pain;Shantotto theme (FFXI event);
-178;The Seven Jesters ;Thornmarch Phase 1;
-179;Good King Moggle Mog XII;Thornmarch Phase 2;
-180;Hubris;Labyrinth of the Ancients;
-181;Tumbling Down;Labyrinth of the Ancients battle;
-182;Agent of Inquiry (short);Hildibrand episode theme;
-183;Frontiers Within ;Revenant's Toll;Daytime theme
-184;Reflections;Revenant's Toll;Nighttime theme
-185;A Light in the Storm ;Pharos Sirius;
-186;Where the Heart Is;Housing Districts (day);
-187;Where the Hearth Is;Housing Districts (night);
-188;Flibbertigibbet;Sylph allied beast tribe area;
-189;Smoulder;Amalj'aa allied beast tribe area;
-190;Discordance (looped);Cutscenes (Mysterious);
-191;Starlight and Sellswords;Aesthetician;1.0 track
-192;Battle Theme 1.x;B-ranks, Hall of the Novice, Various Story and Stone, Sea and Sky;
-193;Big-Boned;Fat Chocobo Theme;
-194;Gluppity-Schlopp;Kobold allied beast tribe area;
-195;Breathless;Sahagin allied beast tribe area;
-196;Pa-Paya;Easter events;
-197;The Scars of Battle;Lost City of Amdapor;
-198;Tempest;Nael deus Darnus Phase 1;
-199;Rise of the White Raven;Nael deus Darnus Phase 2;
-200;Good King Moggle Mog XII;(Thornmarch Phase 2);
-201;Battle on the Big Bridge;(Gilgamesh Boss Theme) 1;
-202;Blades*;The Second and Final Coils;Transitions "Spiral" combat
-203;Wreck to the Seaman;(The Whorleater Phase 1);
-204;Through The Maelstrom ;(The Whorleater Phase 2);
-205;Meteor;Nael Deus Darnus ;
-206;Persistence;Boss themes;
-207;Wrath of the Eikons;Boss themes;
-208;Fury;Brayflox's Longstop HM Boss;1.0 track
-209;Beneath Bloodied Banners ;Hard Mode dungeon bosses;
-210;Birds of a Feather;Halatali Hard mode;1.0 track
-211;Thicker Than a Knife's Blade;;
-212;Now I Know the Truth;Unei and Doga theme;
-213;;;
-214;Moonfire Faire;;Seasonal Event
-215;Far from Home;Ixal theme;
-216;Horizons Calling;Hullbreaker Isle;
-217;Dark Vows;Tam-Tara Deepcroft (HM);
-218;Out of the Labyrinth;The Syrcus Tower;Transitions "Shattered" combat
-219;The War Room;Frontlines;
-220;Rouse Out!;Frontlines;Delayed.Transitions "Blood for Blood" combat
-221;Thunder Rolls ;The Striking Tree;
-222;Game Theory;(Puzzles / Minigames Theme);
-223;Loss of Time;Syrcus Tower cutscene;
-224;Or the Egg?;Chocobo training montage;
-225;His Holiness;Thordan cutscene;
-226;Answers (Reprise);The Rising;
-227;The Corpse Hall ;Urth's Fount;
-228;Everbinding Oath;Eternal Bond ceremony;
-229;The Edge;Ninja trainer hideout;
-230;Footsteps in the Snow ;(Akh Afah Amphitheatre Phase 1);
-231;Oblivion ;(Afk Afah Amphitheatre Phase 2);
-232;Boss Battle (FFVI);The Dragon's Neck;
-233;The Warrens;Snowcloak;
-234;Forgotten by the Sun;Temple of Qarn (Hard);
-235;Riptide;Sastasha (Hard);
-236;From the Ashes;Phoenix Boss Theme;
-237;Answers;(Bahamut Prime Phase 2);
-238;Answers;(Bahamut Prime Phase 3);
-239;The Coil Tightens;(T13 Cinematic);
-240;Answers;(Bahamut Prime Phase 1);
-241;Eternal Wind;Crystal Tower ending cutscene;
-242;Battle on the Big Bridge (FFV);Battle in the Big Keep Phase 1;
-243;Silver Tears;The Keeper of the Lake;
-244;Primogenitor;The Keeper of the Lake (Midgardsormr);Midgardsormr'Brood/AlphaScape v2
-245;Tricksome;Wanderer's Palace (Hard);
-246;Aftermath;Amdapor Keep (Hard);
-247;Blind to the Dark;The World of Darkness;Transitions "Hamartomania" Combat
-248;Tumbling Down (Cerberus Stomach);The World of Darkness;Muffled
-249;Hunger;The World of Darkness;Transitions "The Reach of Darkness" after ending
-250;Four-Sided Circle;Manderville Gold Saucer;
-251;Gateway to Paradise;Chocobo racing 1;
-252;Sport of Kings;Chocobo racing 2;
-253;Shuffle or Boogie;Triple Triad;Straight out of FFVIII
-254;Faith in Her Fury;The Steps of Faith;
-255;Unworthy;The Steps of Faith (pinch);
-256;The Tug of Fate;The Wanderer's Palace HM Bosses;
-257;To the Fore;The Wanderer's Palace HM End Boss;
-258;Chocobo Victory 1;Chocobo racing;
-259;Chocobo Victory 2;Chocobo racing;
-260;Chocobo Victory 3;Chocobo racing;
-261;Drum Roll;Cutscene;
-262;Magiteknical Difficulties;Magitek Armor Mount;
-263;The Corpse Hall Hushed;Sleipnir Mount;
-264;Oblivion Hushed;Shiva Mount;
-265;Thunder Rolls Hushed;Ramuh Mount;
-266;Through The Maelstorm Hushed;Leviathan Mount;
-267;Under the Weight Hushed;Titan Mount;
-268;Fallen Angel Hushed;Garuda Mount;
-269;Primal Judgement Hushed;Ifrit Mount;
-270;;;
-271;A Cold Wind;Heavensward title screen;
-272;Dragonsong;Final Steps of Faith;
-273;Shelter;Heavensward safezone music;
-274;Safety In Numbers;Heavensward safezone music 2;
-275;Nobility Obliges;The Pillars (day);
-276;Nobility Sleeps;The Pillars (night);
-277;Solid;The Foundation (day);
-278;Night in the Brume;The Foundation (night);
-279;Against the Wind ;Coerthas Western Highlands (day);
-280;Black and White;Coerthas Western Highlands (night);
-281;Melt;Heavensward Battle Theme;
-282;Painted Foothills;Dravanian Forelands (Day);
-283;Painted Skies;Dravanian Forelands (Night);
-284;Melt;;
-285;Missing Pages;Dravanian Hinterlands (Day);
-286;The Silent Regard of Stars;Dravanian Hinterlands (Night);
-287;Melt;;
-288;Landlords;Churning Mists (Day);
-289;Skylords;Churning Mists (Night);
-290;Melt;;
-291;Lost in the Clouds;Sea of Clouds (Day);
-292;Close to the Heavens;Sea of Clouds (Night);
-293;Melt;;
-294;Order yet Undeciphered ;Azys Lla;
-295;Melt;;Ever so slight variation
-296;Paradise Found;Idyllshire (Day);
-297;Homestead;Idyllshire (Night);
-298;The Mushroomery;Matoya's cave;
-299;Descent;Dusk Vigil;
-300;Like a Summer Rain;Neverreap;
-301;Slumber Eternal;Sohm Al;
-302;Roar of the Wyrm;The Aery;
-303;Ink Long Dry;Great Gubal Library ;
-304;Imagination ;Aetherochemical Research Facility;
-305;Hallowed Halls ;(The Vault);
-306;Hallowed Halls ;(The Vault area transition);
-307;Hallowed Halls ;(The Vault area transiiton 2);
-308;Unbreakable;Fractal Continuum;
-309;Ominous Prognisticks;(Heavensward Boss theme);
-310;The Hand That Gives The Rose;(Thok ast Thok Phase 1);
-311;Limitless Blue;(The Limitless Blue);
-312;Heroes;(The Singularity Reactor);
-313;Contention;Heavensward cutscenes/Zenith;
-314;Misconception;Heavensward cutscenes;
-315;The Heavens' Ward ;(Heavens' Ward Knight Theme);
-316;Stone and Steel;HW Heroic Theme (Cutscenes/Instances);
-317;For the Sky;Heavensward cutscenes;
-318;Inception;Heavensward cutscenes;
-319;Borderless;Flying mount theme;
-320;The Dragon's Dirge (looped);Ishgard locations;
-321;Ultima (excerpt);Proto Ultima;
-322;What is Love?;Moogle Beast Tribe;
-323;Sins of the Father, Sins of the Son;Alexander;
-324;Locus;Alexander boss theme;
-325;Unbending Steel;(Thok ast Thok Phase 2);
-326;Woe That Is Madness;(The Limitless Blue Phase 2);
-327;Metal;(Alexander Boss Theme - The Manipulator);
-328;When a Tree Falls;FC workshop/leves;1.0 track
-329;Eerie Church Bells;Steps of Thal;1.0 Original Ul'dah Church
-330;All Saint's Wake Theme;Event;Seasonal Event
-331;Steel Reason Hushed;Red Baron/White Devil mounts;
-332;Battle Theme;The Maiden's Rhapsody (FFXI);
-333;Battle Theme #2;The Maiden's Rhapsody (FFXI);
-334;Recollection;The Maiden's Rhapsody (FFXI);
-335;The Kingdom of San d'Oria;The Maiden's Rhapsody (FFXI);
-336;The Republic of Bastok;The Maiden's Rhapsody (FFXI);
-337;The Federation of Windurst;The Maiden's Rhapsody (FFXI);
-338;Palace of the Dead Theme;POTD;
-339;Sea of Clouds theme;Abalathia's Spine;Daytime
-340;Sea of Clouds theme;Abalathia's Spine;NightTime
-341;Heroes Never Die ;(The Singularity Reactor EX);
-342;Engage;The Diadem;
-343;Jewel;The Diadem (Battle);
-344;Torn from The Heavens;Diadem NM Battle;
-345;Poison Ivy;Saint Mocianne's Arboretum ;
-346;Upon the Rocks;Pharos Sirius (Hard);
-347;Aetherpause;Void Ark;Transitions In Darkness, There Is One. Combat
-348;Voidal Manifest;Shadow of Mhach boss music;
-349;Lord of Verminion Selection theme;LOV Minigame;
-350;Brothers in Arms;Palace of the Dead bosses;
-351;Nemesis;Dungeon boss battles;
-352;The Dark's Kiss;Palace of the Dead;
-353;Aftermath;Palace of the Dead;
-354;The Corpse Hall;Odin;
-355;Battle on the Big Bridge;(Gilgamesh' theme);
-356;Spiral;First Coil Ambient;
-357;Calamity Unbound;Twintania battle;
-358;Prelude ~ Rebirth Hushed;Kirin mount;
-359;The Kiss;Valentione's Day;
-360;Spriggan's Adventure;;Likely test or filler audio
-361;Down the Up Staircase;The Antitower;
-362;Calca Boss Fight;The Antitower;
-363;Vath Beast Tribe;;
-364;Vath Beast Tribe;;
-365;Battle to the Death;Heavensward (Warring Triad Phase 1);
-366;Fiend;(Containment Bay S1T7 Phase 2 / Sephirot);
-367;Feast Theme;;
-368;The Ancient City;The Lost City of Amdapor (Hard);
-369;Metal - Brute Justice Mode ;(Alexander Boss Theme - Brute Justice);
-370;Alexander background beat;;Likely test or filler audio
-371;Woe That is Madness Hushed;Bismarck Mount;
-372;Unbending Steel Hushed;Ravana Mount;
-373;Heroes Hushed;Thordan Mount;
-374;Sephirot P1 Hushed;Sephirot Mount;
-375;Tenacity;Levequests (Palace of the Dead);
-376;From the Ashes Hushed;Bennu Mount;
-377;Faith in Her Fury (excerpt);3.3 cutscenes;
-378;Stone and Steel (excerpt);3.3 cutscenes;
-379;Primogenitor (excerpt);3.3 cutscenes;
-380;Hyper Rainbow Z;Go Go Posing Rangers Theme;
-381;Freedom;Sky Pirate area (The Parrock);A 1.0 La Noscea theme
-382;Dragonsong;(The Final Steps of Faith Phase 1);
-383;Freefall ;(The Final Steps of Faith Phase 2);
-384;Revenge of the Horde;(The Final Steps of Faith Phase 3);
-385;He Who Continues the Attack;Regula Hydrus's Theme;
-386;Apologies;(Sohr Khai);
-387;Holy Consult ;(Hullbreaker Hard Isle);1.0 track
-388;Bathed in Woodsin;Review;1.0 track
-389;Emerald Labyrinth;POTD;1.0 track
-390;Enraptured ;POTD;1.0 track
-391;Tears for Mor Dhona;POTD;1.0 track
-392;Blackbosom;POTD Floor 50 boss;
-393;Teardrops in the rain;Weeping City of Mhach;
-394;A thousand faces (Ozma theme);Weeping City of Mhach;
-395;Freefall Hushed;Nidhogg Mount;
-396;Good King Moggle Mog XXII Hushed;Fat Moogle Mount;
-397;Locus Hushed;Gobwalker Mount;
-398;Foundation piano;;
-399;Palace of the Dead Theme;;
-400;Fragments of Forever;Alisaie Theme;
-401;Notice of Death;100 potd forboding;
-402;Equilibrium ;(Containment Bay P1T6 / Sophia);
-403;The Gauntlet;Wolves Den duel / Lost Canals of Uznair;
-404;Ultima Theme;;
-405;Grounded;Xelphatol;
-406;Revenge Twofold ;Heavensward 3.4/3.5 Boss Theme;
-407;Bibliophobia;Gubal Hard;
-408;Up at Dawn;Halloween Instance Event Music;
-409;Fog of Phantom;91-100 potd theme;
-410;Blasphemous Experiments;Potd 100 Boss (Nybeth Obdilord);
-411;Exponential Entropy;Alexander Boss Theme - Cruise Chaser;
-412;Mobius;Alexander Boss Theme - A12 Phase 1;
-413;Rise;Alexander Boss Theme - A12 Phase 2;
-414;Rise Ambient;Alexander Boss Theme Non Vocal Phase 2 Gate Adds;
-415;Equilibrium Hushed;Sophia Mount;
-416;Mobius Hushed;A12s Mount;
-417;Infinity;Containment Bay Z1T9 / Zurvan Phase 3;
-418;Elevator Waiting Music;Unused Gold Saucer Transition;Floor Transitions
-419;Penultimania ;Containment Bay Z1T9 / Zurvan Phase 2;
-420;Another Brick;Baelsar's Wall theme;
-421;Quicksand;Solm Al Hard Theme;
-422;Promises;Deathgaze theme(Dun Scaith);
-423;Shadow of the Body;Dun Scaith ambient;
-424;Infinity Hushed;Zurvan Mount;
-425;Mother Crystal/Yoship theme;Crystal Theme / Yoshi-p Events;
-426;Answers - Reprise;Original 1.xb Ending Update;
-427;;;
-428;Prelude - Long March Home;Stormblood login screen;
-429;Revolutions(Vocals);;
-430;Harmony;Stormblood safezone1;
-431;With Giants Watching;Stormblood safezone1;
-432;Cradle;Stormblood safezone1;
-433;Impact;Rhalgr's Reach;Daytime theme
-434;Afterglow;Rhalgr's Reach;Nighttime theme
-435;Looping in the Deepest Fringes;Stormblood battle theme;
-436;Crimson Sunrise;Kugane;Daytime theme
-437;Crimson Sunset;Kugane;Nighttime theme
-438;Looping in the Deepest Fringes;Stormblood battle theme;
-439;Beyond The Wall;The Fringes;Daytime theme
-440;Hope Forgotten;The Fringes;Nighttime theme
-441;Looping in the Deepest Fringes;stormblood battle theme;
-442;On High;The Peaks;Daytime theme
-443;The Stone Remembers;The Peaks;Nighttime theme
-444;Looping in the Deepest Fringes;stormblood battle theme;
-445;Songs of Salt and Suffering;The Lochs;Daytime theme
-446;Old Wounds;The Lochs;Nighttime theme
-447;Looping in the Deepest Fringes;stormblood battle theme;
-448;Liquid Flame;The Ruby Sea;Daytime theme
-449;Westward Tide;The Ruby Sea;Nighttime theme
-450;Looping in the Deepest Fringes;stormblood battle theme;
-451;A Father's Pride ;Yanxia;Daytime theme
-452;A Mother's Pride;Yanxia;Nighttime theme
-453;Looping in the Deepest Fringes;stormblood battle theme;
-454;Drowning in the Horizon;The Azim Steppe;Daytime theme
-455;He Rises Above;The Azim Steppe;Nighttime theme
-456;Looping in the Deepest Fringes;stormblood battle theme;
-457;Stormblood cutscene music 1;;
-458;Stormblood cutscene music 2;;
-459;Heroes of Stormblood;Stormblood cutscenes;
-460;The Garlean Territorial Anthem;Gyr Abania / Neighbor States;
-461;Measure of His Reach(nonvocal);;
-462;8 bit adventure;Reused FF Theme /;Unused
-463;Stormblood cutscene music 3;;
-464;Cyan's Theme;Cutscenes/The Doman Enclave;
-465;Far East of Eorzea;Cutscene music;
-466;Revelation ;(The Pool of Tribute Phase 1);
-467;Beauty's Wicked Wiles;(Emanation);
-468;Scale and Steel;(The Royal Menagerie Phase 1);
-469;The Worm's Tail;(The Royal Menagerie Phase 2);
-470;Triumph;Stormblood Boss Theme;
-471;Dawnbound;(The Sirensong Sea);
-472;The Open Box ;(The Shisui of the Violet Tides);
-473;Most Unworthy;(Bardam's Mettle);
-474;Gates of the Moon;(Doma Castle);
-475;Alienus;(Castrum Abania);
-476;Liberty or Death ;(Ala Mhigo);
-477;Their Deadly Mission;(Temple of the fist);
-478;Deception;(Kugane castle);
-479;Deltascape;Omega Hub;
-480;Omega^2;Deltascape Bosses;
-481;Decisions;Deltascape;Exdeath 
-482;Final Not Final;Neo Exdeath;O4 Savage
-483;Wing and a Prayer Hushed;Falcon Porters;
-484;Wing and a Prayer;Various cutscenes/Enclave Quests;
-485;Revolutions (Cutscene version);;
-486;Prelude (Long March Home)ARR;Stormblood Character Selection;
-487;Measure of His Reach - Prelude;StormBlood ARR/SB Mix;
-488;Shell-Shocked;Isle of Zekki;
-489;Parting Ways;Cutscenes (Sad Eastern Theme);
-490;Meteor;Cutscenes (Zenos Insert Theme);
-491;Riot ;(The Pool of Tribute Phase 2);
-492;At Both Ends;(The Pool of Tribute Phase 3);
-493;Riot Hushed;Susano Mount;
-494;Beauty's Wicked Wiles Hushed;Lakshima Mount;
-495;Procedamus in Peace;Rhalgr's Reach (Ruined);
-496;Wizardly;FFXIV Anniversary Maze;
-497;A Great Success;Choco Racing Victory;
-498;Indomitable ;(Tamamizu / Kojin Theme);
-499;Beyond Redemption;Unending coil of Bahamut (Ultimate);(Golden Bahamut Theme)
-500;Rival Wings;Astralogos;
-501;Locus;Alexander (Rival Wings Oppressor);
-502;Exponential Entropy;Alexander (Rival Wings Cruise Chaser);
-503;Metal-Brutal Justice Mode;Alexander (Rival Wings Brute Justice);
-504;Far From Home;(The Drowned City Of Skalla);
-505;The Worm's Tail Hushed;Shinryu Mount;
-506;Trisection;(Royal City of Rabanastre Theme);
-507;Precipitous Combat;(Rabanastre Boss Theme);
-508;Ultima's Transformation;(Rabanastre Final Boss Theme);
-509;Victory;Royal City of Rabanastre;
-510;Save / Load Screen;Return to Ivalice cutscenes;
-511;Character Creation;Return to Ivalice cutscenes;
-512;Protagonist's Theme;Return to Ivalice cutscenes;
-513;Stormblood alliance cutscene music;Royal City of Rabanastre;
-514;Background Story;Return to Ivalice cutscenes;
-515;The Enemy Approaches;Return to Ivalice cutscenes;
-516;Starlit Gateway;Christmas 2017;Seasonal Event
-517;Forever in Flames;;Short Theme
-518;Keepers of the Lock;Ananta Beast tribe music;
-519;Iroha;Reisen Temple;
-520;Siren Song;Steps Of Nald;Seasonal Event
-521;Answer on High;The Four Lords;
-522;Todoroki;The Jade Stoa (Phase 2);
-523;Amatsu Kaze;The Jade Stoa (Phase 3);
-524;Wicked Winds Whisper;Eureka Anemos/Pagos/Pyros;
-525;No Quarter;Eureka Fates;
-526;Down Where Daemons Dwell;(Hells' Lid);
-527;Unbreakable - Duality ;(The Fractal Continuum Hard);
-528;The Phantom Train to Sigmascape;Sigmascape Boss Train;
-529;The Decisive Battle;Sigmascape Boss Theme;
-530;Dancing Mad (Phase 1 - Sigma v4.0);Sigmascape;
-531;Dancing Mad (Phase 2 - Sig v4.0);Sigmascape;
-532;Dancing Mad (Phase 3 - Sig v4.0);Sigmascape;
-533;Dancing Mad (God Kefka);Sigmascape;O8 Savage
-534;Final Not Final Hushed;Mount;
-535;Dancing Mad IV Hushed;Mount;
-536;Amatsu Kaze Hushed;Mount;
-537;Calling;Eureka;Short- No Repeat
-538;Pa-Paya Demastered ;(Easter Mini-game Theme);Seasonal Event
-539;Valentine Love Checker Theme;Old Gridania;Seasonal Event
-540;Seven Hundred Seventy-Seven Whiskers;Namazu beast tribe area;
-541;Nightbloom;Tsukuyomi Phase 1;
-542;Lunacy;Tsukuyomi Phase 2;
-543;Wayward Daughter;Tsukuyomi Phase 3;
-544;Fallen Angel (From Astral to Umbral);~UwU Garuda;
-545;Primal Judgment (From Astral to Umbral);~UwU Ifrit;
-546;Under the Weight (From Astral to Umbral);~UwU Titan;
-547;Ultima (Orchestrial Version);~UwU Ultima Weapon;
-548;Monster Hunter World Rathalos;Phase 2;Monster Hunter World
-549;Monster Hunter World Rathalos;Phase 1;Monster Hunter World
-550;Monster Hunter World Result Screen;Completion of Duty;Monster Hunter World
-551;Earth Wind and Water;Swallow's Compass;
-552;Wayward Daughter Hushed;Tsukuyomi Mount;
-553;World Map;FF/TCS;
-554;A Chapel;FF/TCS;
-555;To the Peak;(Ridorana Lighthouse);
-556;The Mystery of Giruvegan ;(Ridorana Lighthouse);
-557;FFXII Boss Theme ;(Ridorana Lighthouse);
-558;Apoplexy (Construct 7);(Ridorana Lighthouse);
-559;Flash of Steel (Yiazmat);(Ridorana Lighthouse);
-560;Victory Fanfare (FFXII version);(Ridorana Lighthouse);
-561;Corner of the New World - Astera;Monster Hunter World;Monster Hunter World
-562;Monster Hunter World;Monster Hunter World;Monster Hunter World
-563;Monster Hunter World;Monster Hunter World;Rathalos introductory cutscene
-564;Monster Hunter World;Monster Hunter World;Monster Hunter World
-565;Monster Hunter World;Monster Hunter World;Monster Hunter World
-566;Kugane MHW Theme;Kugane;Daytime Theme
-567;Kugane MHW Theme;Kugane;Nighttime Theme
-568;Looping in the Deepest Fringes;Stormblood battle variation;Kugane
-569;UWU Magitek Bit;~UwU;Creepypasta edition
-570;Wasshoi, Wasshoi!;Mikoshi mount;
-571;Monster Hunter Theme;Generic;
-572;Rathalos wipe;Failed Duty;Party Wipes/Out of Revives
-573;Everywhere and Nowhere;AlphaScape/Cutscene;Alpha in Space
-574;A Dream in Flight;AlphaScape/Cutscene;Alpha&Omega Adventure
-575;Ending;AlphaScape/Cutscene;Alpha&Omega Adventure
-576;Ending 2;AlphaScape/Cutscene;Epilogue
-577;Unspoken;1.0 Coerthas;
-578;Inner Recess;;Encounter
-579;Neverborn;;
-580;Starlight, Starbright;Old Gridania;Seasonal Event
-581;Sunset;Hells' Kier;
-582;Sunrise;Hells' Kier Phase 3;
-583;A Land Long Dead ;(The Burn);
-584;From Mud;(Saint Mocianne's Arboretum Hard);
-585;Battle (Alphascape v1.0);Alphascape;
-586;eScape (Alphascape v3.0);Alphascape;
-587;Heartless (Omega M+F Theme);Alphascape;O12
-588;Sunrise Hushed;Suzaku Mount;
-589;From the Heavens Hushed;Alphascape Mount;
-590;Bedlam's Brink;Solus Soz Galvus;
-591;From the Heavens Final Omega;Alphascape;O12 Savage
-592;Crazy Motorcycle;SDS Fenrir Mount;
-593;Dangertek;The Shifting of Altar of Uznair/Feast;
-594;N/A;;
-595;N/A;;
-596;N/A;;
-597;N/A;;
-598;N/A;;
-599;N/A;;
-600;N/A;;
-601;N/A;;
-602;N/A;;
-603;N/A;;
-604;Broken Down;Final Fantasy XV;
-605;Hammerhead;Final Fantasy XV;
-606;Valse di Fantastica;Final Fantasy XV;
-607;Relax and Reflect;Final Fantasy XV;
-608;Daemons;Final Fantasy XV;
-609;Prayer de LUNA;Final Fantasy XV;
-610;Safe Haven;Final Fantasy XV;
-611;Veiled in Black;Final Fantasy XV;
-612;Horrors of the Night;Final Fantasy XV;
-613;Apocalypsis Notic;Final Fantasy XV;
-614;A Quick Pit Stop;Final Fantasy XV;
-615;Prima Vista;Prima Vista;
-616;Banga Banga Theme;Kugane CutScene;
-617;Gentle Theme (stops after awhile);Orbonne Monastery;
-618;Adventure Theme;Orbonne Monastery;
-619;Adventure Theme 2;Orbonne Monastery;
-620;Alma's Theme;Orbonne Monastery;
-621;Adventure Theme 3;Orbonne Monastery;
-622;Adventure Theme 4;Orbonne Monastery;
-623;Boss Theme;Orbonne Monastery;
-624;Boss Theme;Orbonne Monastery;
-625;Boss Theme;Orbonne Monastery;
-626;Boss Theme;Orbonne Monastery;
-627;Boss Theme;Orbonne Monastery;
-628;Boss Theme;Orbonne Monastery;
-629;Victory Theme;Orbonne Monastery;
-630;Nail of the Heavens;Blue Mage Carnival;
-631;Azulmagia fight;Blue Mage Carnival;
-632;The Garden of Ru'Hmet;Baldesion Arsenal;
-633;Onslaught;Baldesion Arsenal;
-634;Turmoil;Baldesion Arsenal;
-635;From the Dragon's Wake Hushed;Seiryu Mount;
-636;StormBlood Theme;Kyubi Mount;
-637;HullBreaker;Mount BGM Faded;
-638;Mount theme;Mount BGM Faded;
-639;Battle for Eorzea (MSQ);The Ghimlyt Dark;
-640;From the Dragon's Wake;The Wreath of Snakes Final Phase;
-641;Doman Distractions;Gold Saucer;
-642;Air Force One Victory;Gold Saucer;
-643;Air Force One Fail;Gold Saucer;
-644;Air Force One Loop;Gold Saucer;
-645;Revolutions + His&Her Revelations;Rising Stones;The End Credits
-646;ShadowBringers;n/a;The arrival of WOD/WOL
-647;Tomorrow and Tomorrow - Reprise;The First;
-648;A Better Tomorrow;The First;
-649;Tears in the Rain;The First;
-650;Dangerous Words;Solo Instance;MSQ / Side Quest Instances
-651;High Treason;Solo instance;MSQ / Side Quest Instances
-652;More than Truth;Cutscenes;
-653;Paradisaical Predicaments;n/a;Post MSQ
-654;Tomorrow and Tomorrow inst.;;
-655;Tomorrow and Tomorrow vocal.;;
-656;Vamo' alla flamenco;Certain Dancer CGS;Dancer 
-657;Piano Short;n/a;
-658;The Lute;n/a;
-659;The Dark Which Illuminates the World;Crystarium (Day/Light);
-660;Knowledge Never Sleeps;Crystarium (Night);
-661;The Indulgence;Eulmore (Day);
-662;Masquerade;Eulmore (Night);
-663;The Source;Lakeland (Day/Light);
-664;Unchanging, Everchanging;Lakeland (Night);
-665;A World Divided;Kholusia (Day);
-666;The Quick Way;Kholusia (Night);
-667;Sands of Amber;Amh Araeng (Day/Light);Orchastration roll
-668;Sands of Blood;Amh Araeng (Night);
-669;Fierce and Free;Il Mheg (Day/Light);
-670;The Faerie Ring;Il Mheg (Night);
-671;Civilizations;Rak'tika Greatwood (Day/Light);Orchastration roll
-672;A Hopeless Race;Rak'tika Greatwood (Night);
-673;Full Fathom Five;The Tempest;
-674;Neath Dark Waters;The Tempest (Amaurot);the Gentile Giant Folk
-675;A Reason to Live;Tomra, Lydha Lran, ???, etc.;Beast Tribe Towns
-676;No Greater Sorrow;Inn at Journey's Head, Twine, etc.;ShB Town Theme
-677;Rencounter 1;;
-678;Rencounter 2;;
-679;Rencounter 3;;
-680;Rencounter 4;;
-681;Rencounter 5;;
-682;N/A;;
-683;What Angel Wakes Me;The Dancing Plague;
-684;Insanity;The Crown of Immaculate;
-685;Who Brings Shadow;;
-686;Invincible;;
-687;To Fire And Sword;The Holminister Switch;
-688;Figments;Dohn Mheg;
-689;Unwound;Qitana Ravel;
-690;Deep Down;Malikah's Well;
-691;In The Belly Of The Beast;Mt. Gulg;
-692;Mortal Instants;Amourot;
-693;Shadows Withal;Acedmia Anyders;
-694;A Long Fall;The Twinning;
-695;Insatiable;Lyhe Giah;
-696;Blue Fields;The Empty;
-697;Force Your Way;Eden's Gate:Resurrection/Descent;
-698;Landslide;Eden's Gate:Sepulture;
-699;On Our Fates Alight;;
-700;What Angel Wakes Me;The Dancing Plage EX;(Mount)
-701;Insanity;The Crown of Immaculate EX;(Mount)
-702;Landslide;Eden's Gate:Sepulture Savage;(Mount)
-703;Four-sided Circle;The Gold Saucer;
-704;Four-fold Knowing;Login Screen;
-705;Who Brings Shadow+TaT;The End Credits;
-706;Locus (The Primals);The Twining;
-707;Tomorrow and Tomorrow 1;;
-708;Tomorrow and Tomorrow 2;;
-709;Tomorrow and Tomorrow (No vocals);;
-710;Shattered;;
-711;Pain in Pleasure;;
-712;Such as it Is;;
-713;N/A;;
-714;The Darks' Kiss;;
-715;On Our Fates Alight;All Locations;Amaro Porter/Mount Music
-716;Unmatching Pieces;Kholusia (Everlasting Light);
-717;Blinding Indigo;Eden's Gate:Inundation;
-718;Starlight, De Chocobo;Old Gridania;
-719;The Garden's Gates;il mheg;
-720;Safety in Numbers;The Firmament;
-721;Kai-Shirr Customs;Eulmore;
-722;Give it your all;Pvp;Orginaly Place id for Locus Remix
-723;Metal - Brutal Justice Remix (Phase 2);Ultimate Alex;
-724;TimeStop;Ultimate Alex;
-725;Rise - Remix (Third Phase);Ultimate Alex;
-726;Moebius Orchestra (Final Phase);Ultimate Alex;
-727;The Grand Cosmos;The Grand Cosmos;
-728;Invincible;The Dying Gasp;(Mount)
-729;Onsal Hakair;Danshing Nadaam;(Mount)
-730;Feast PVP;Wolves Den pier;
-731;Imperium;The Masked Carnivale;(Mount)
-732;Significance - Nothing;The Copied Factory - Nier Automata OST;
-733;City Ruins - Rays of Light;The Copied Factory - Nier Automata OST;
-734;Vague Hope;The Copied Factory - (Quest Area);
-735;;;
-736;Voice of No Return;The Copied Factory - (Quest Area);
-737;Alien Manifestation;The Copied Factory - Nier Automata OST;
-738;Song of the Ancients - Atonement;The Copied Factory - Nier Automata OST;
-739;Bipolar Nightmare;The Copied Factory - FFXIV Collab;
-740;Weight of the World - Prelude Version ;The Copied Factory - FFXIV Collab;
-741;Crumbling Lies;The Copied Factory - (Quest Area);
-742;Where I Belong;;FFVIII
-743;Hopl's Dropple;Hopl's Stopple;
-744;Bozjan Resistance;Grandor;
-745;8-Papaya Adventures Theme;;
-746;Ultima (Primals);The Cinder Drift (Extreme);
-747;Painful Memories;The Firmament;
-748;ShadowBringers Mid-Boss Remix;Anamnesis Anyder;
-749;Floundering in the Depths;Anamnesis Anyder;
-750;Twice Stricken;Eden's Verse:Fulmination;
-751;Primal Angel;Eden's Verse:Furor;
-752;Return to Oblivion;Eden's Verse:Refulgence;
-753;Ultima (Primals);The Cinder Drift (Extreme);(Mount)
-754;Twice Stricken;Eden's Verse:Fulmination (Savage);(Mount)
-755;Rise of The White Raven;The Cinder Drift (2nd Phase);
-756;Horizons Calling;;(Mount)
-757;Holy Consult;;
-758;When a Tree Falls;Free Company Workshop;
-759;Oblivion's Refusal;Eden's Verse:Refulgence;
-760;Eternal Winds - Piano Solo;;
-761;Eternal Winds - ShadowBringer;;Short version
-762;Tomorrow and Tomorrow;;
-763;ARR Ending theme;;
-764;Exarch's Hope;The Seat of Sacrifice;
-765;Moonfire Faire Event;Costa Del Sol;
-766;Watts's Anvil;Lakeland;
-767;Sapphire Dreams;Terncliff;
-768;ShadowBringer's 5.3 Trailer theme;;
-769;Ascendence Phase;The Seat of Sacrifice;
-770;N/A;;
-771;To The Edge;The Seat of Sacrifice;
-772;Wind on the Plains;The Bozjan Southern Front;
-773;Discord: Imperial (Zodiac Age Version);The Bozjan Southern Front;
-774;Into the Fortress (Zodiac Age Version);The Bozjan Southern Front;
-775;Battle with an Esper (Zodiac Age Ver);The Bozjan Southern Front;
-776;Life and Death (Zodiac Age Version);The Bozjan Southern Front;
-777;Where All Roads Lead;The Heroes Gauntlet;(Mount)
-778;To The Edge;The Seat of Sacrifice (Extreme);(Mount)
-779;Discord: Imperial (Zodiac Age Version);The Bozjan Southern Front;(Mount)
-780;Broken Heart;The Puppet's Bunker - nier Automata ;Quest instance
-781;Rays of Light (Instrumental);The Puppet's Bunker - nier Automata ;Solo / Cutscenes
-782;Amusement Park;The Puppet's Bunker - nier Automata ;Quest instance
-783;Fortress of Lies;The Puppet's Bunker - Raid;
-784;Grandma - Destruction;The Puppet's Bunker - Raid;
-785;End of the Unknown;The Puppet's Bunker - Raid;
-786;Torn From the Heavens/TDCDA (Medley);The Puppet's Bunker - Raid;Final Boss
-787;Unrest (Zodiac Age Version);The Bozjan Southern Front;
-788;???;;
-789;Heavensward;City of Giants (Solo Instance);
-790;Stormblood;City of Giants (Solo Instance);
-791;N/A;;
-792;The Black Wolf Stalks Again;Castrum Marinum;Golden Emerald Weapon
-793;N/A;;
-794;N/A;;
-795;N/A;;
-796;N/A;;
-797;???;;
-798;Freshly-Baked Porxie;Matoya's Relict;
-799;Don't Be Afraid;Eden's Promise - Umbra/Litany;
-800;The Legendary Beast;Eden's Promise - Anamorphosis;
-801;Promises to Keep;Eden's Promise - Eternity;
-802;Promises to Keep ;Eden's Promise - Eternity (Savage);
-803;The Black Wolf Stalks Again (Mount);Castrum Marinum;
-804;Promises to Keep (Mount);Eden's Promise - Eternity (Savage);
-805;N/A;;
-806;Forgotten Promises;Eden's Promise;
-807;;;
-808;;;
-809;;;
-810;;;
+"ID","Name","Locations","Comments"
+"0","None","",""
+"1","Null BGM","","Empty sound"
+"2","Prelude - Rebirth","A Realm Reborn title",""
+"3","Dreams Aloft","Cid cutscenes","Old launcher theme, from 1.0"
+"4","Prelude - Discoveries","Character Select & Creation",""
+"5","Behind Closed Doors","Inn theme",""
+"6","Wailers and Waterwheels","Gridania (day)",""
+"7","Dance of the Fireflies","Gridania (night)",""
+"8","Serenity","Central/North Shroud",""
+"9","Serenity","Black Shroud sanctuaries",""
+"10","Serenity","The Black Shroud",""
+"11","Serenity","South Shroud",""
+"12","Serenity","Sanctum of the Twelve",""
+"13","The Land Bends","The Black Shroud combat",""
+"14","Tenacity","Leves",""
+"15","Slumber Disturbed","The Tam-Tara Deepcroft",""
+"16","The Promise of Plunder","Early ARR Dungeons",""
+"17","The Dark's Embrace","ARR HM Dungeons","Transitions to ""The Dark's Kiss"" in combat"
+"18","Victory!","End of most instances",""
+"19","","",""
+"20","Victory!","End of most instances","No vocals 21"
+"21","Victory!","End of most instances",""
+"22","???","Frontlines","Gate open theme"
+"23","The Hero of Hatchingtide","","Chiptune version of 21 (Victory)"
+"24","Greenwrath","East Shroud",""
+"25","I Am the Sea","Limsa Lominsa (day)",""
+"26","A Sailor Never Sleeps","Limsa Lominsa",""
+"27","On Westerly Winds","Middle/Lower La Noscea",""
+"28","On Westerly Winds","La Noscea",""
+"29","On Westerly Winds","Eastern La Noscea",""
+"30","On Westerly Winds","Eastern La Noscea",""
+"31","On Westerly Winds","La Noscean sanctuaries",""
+"32","Currents","La Noscea",""
+"33","The Land Breathes","La Noscea combat",""
+"34","","",""
+"35","From the Depths","Sastasha",""
+"36","Torn from the Heavens","Various",""
+"37","A Fine Death","ARR Dungeon bosses",""
+"38","Nemesis","ARR Dungeon final bosses",""
+"39","Pennons Aloft","Instanced battles",""
+"40","Brothers in Arms","Guildhests",""
+"41","The Maiden's Lament","Haukke Manor",""
+"42","A Thousand Screams","The Thousand Maws of Toto-Rak",""
+"43","Lipflaps on Longstops","Brayflox's Longstop",""
+"44","A New Hope","Ul'dah (day)",""
+"45","Sultana Dreaming","Ul'dah (night)",""
+"46","To the Sun","Western/Central Thanalan",""
+"47","To the Sun","Thanalan",""
+"48","To the Sun","Southern Thanalan",""
+"49","To the Sun","Thanalan sanctuaries",""
+"50","To the Sun","Thanalan",""
+"51","Fleeting Rays","Eastern Thanalan",""
+"52","The Land Burns","Thanalan combat",""
+"53","Below","Copperbell Mines",""
+"54","The Ludus","Halatali",""
+"55","The Gift of Life","Thanalan sanctuaries",""
+"56","Calling","",""
+"57","Discordance","Northern Thanalan",""
+"58","Beyond the Unknown","Cutscene (Edda)","Very short"
+"59","Slither","Northern Thanalan outskirts","Very short and sounds similar to Discordance"
+"60","Intertwined","Mor Dhona",""
+"61","Bo-down","Chocobo porters",""
+"62","Eorzea de Chocobo","Chocobo mounts",""
+"63","Into the Adder's Den","Twin Adder command",""
+"64","Maelstrom Command","Maelstrom command",""
+"65","The Hall of Flames","Immortal Flames command",""
+"66","The Waking Sands","Western Thanalan",""
+"67","When a Tree Falls","Leves",""
+"68","The Tug of Fate","Certain FATEs",""
+"69","To the Fore","Certain FATEs/Boss battles",""
+"70","Whisper of the Land ","Cutscenes (1.0)",""
+"71","On Windy Meadows","Cutscenes (1.0)",""
+"72","Twilight Over Thanalan","Cutscenes (1.0)",""
+"73","Dewdrops & Moonbeams","The Lotus Stand (Kan-E-Senna)",""
+"74","The Sands' Secrets","Eorzean Alliance (Raubahn)",""
+"75","Ripples in the Sea","Eorzean Alliance (Merlwyb)",""
+"76","Imperial Will","Cutscenes (Empire)",""
+"77","Defender of the Realm","Cutscenes (Heroic)",""
+"78","Fracture","Cutscenes (Suspense)",""
+"79","One Blood","Cutscenes (Tension)",""
+"80","Conundrum","Cutscenes (Mysterious/Hildibrand)",""
+"81","Prelude - Rebirth","Cutscenes","Remix with a slightly different harp"
+"82","Return of the Hero","Cutscenes (Resolution)",""
+"83","Kiss of Chaos","Cutscenes (Tension)",""
+"84","Forever Lost","Cutscenes (Sad)",""
+"85","Machinations","Wolves' Den / Northern Thanalan Sanctuaries",""
+"86","The Only Path","Cutscenes (Positive)",""
+"87","Daring Dalliances","Cutscenes (Positive)",""
+"88","Bliss","Cutscenes (Comedic)",""
+"89","A World Apart","Cutscenes (Heroic)",""
+"90","Relics","Cutscenes (esp. Job quests)",""
+"91","Breaking Boundaries","Job quest battles",""
+"92","The Echo","Cutscenes",""
+"93","Tranquility","Cutscenes (Resolution)",""
+"94","Without Shadow","Cutscenes (Ascians)",""
+"95","The Seventh Sun","Cutscenes",""
+"96","Sacred Bonds","Cutscenes (Sad)",""
+"97","Canticle","Cutscenes (Exposition)",""
+"98","Where the Heart Is","Cutscenes (Resolution)","1.0 track"
+"99","Dreams Aloft","Cutscenes (Resolution)",""
+"100","Supply & Demand","Cutscenes (Comedic)","1.0 track"
+"101","By Design","Cutscenes (Comedic)","1.0 track"
+"102","Decisions","Cutscenes (Mysterious), Little Ladies' Day","1.0 track"
+"103","Agent of Inquiry","Hildibrand Theme",""
+"104","","",""
+"105","Nature's Bounty","Cutscenes, Eternal Bonding","1.0 track"
+"106","Falling Shards","Various, Eternal Bonding","Harp-only version of Prelude"
+"107","Pennons Aloft","Instanced battles, Fenrir battle","1.0 track"
+"108","Battle Theme 1.x","Hildibrand FATEs/Hall of the Novice/B-ranks",""
+"109","","",""
+"110","Salt Swept","Aleport/Moraby Drydocks",""
+"111","Paris Themed","Limsa Lominsa",""
+"112","My Soul to Keep","Haukke Manor/Tam-Tara HM",""
+"113","From Fear to Fortitude","Instanced battles",""
+"114","Damnation","Cutscenes (Suspense)",""
+"115","Hard to Miss","Boss FATEs",""
+"116","A Fell Air Falleth","Later ARR Dungeons",""
+"117","Skullduggery","Instanced battles/Qarn HM",""
+"118","Another Round","Bars and Taverns",""
+"119","Ruby Sunrise","Costa del Sol",""
+"120","Primal Judgement ","The Bowl of Embers",""
+"121","The Rider's Boon","ARR mounts",""
+"122","Cracks in the Wall","Amdapor Keep",""
+"123","A Tonberry's Tears","The Wanderer's Palace",""
+"124","Echoes of Ages Past","The Sunken Temple of Qarn",""
+"125","Abomination","Cutter's Cry",""
+"126","Cold Salvation","The Stone Vigil",""
+"127","The Darkhold","Dzemael Darkhold",""
+"128","Miser's Folly","The Aurum Vale",""
+"129","Engage","The Enterprise",""
+"130","Fever Dream","Cutscenes (Tension)","Excerpt from a longer 1.0 track"
+"131","Serving the Light","Warrior of Light",""
+"132","Answers","ARR End Credits",""
+"133","Opening Theme","ARR End Credits Special/1.0 players","1.0 ending"
+"134","A Curious Breed of Botherment","Sylph Theme song",""
+"135","Flightless Wings","Ixal Theme song",""
+"136","Quick as Silver, Hard as Stone","Kobold theme song",""
+"137","Battle Drums ","Sahagin theme song","1.0 track"
+"138","Pitfire","Amalj'aa theme song","1.0 track"
+"139","","",""
+"140","","",""
+"141","Fealty","Coerthas Central Highlands",""
+"142","The Dragon's Dirge","Coerthas Central Highlands (Whitebrim)",""
+"143","Undying Faith","Coerthas Central Highlands (Observatorium)",""
+"144","The Land Breaks","Coerthas Central Highlands battle",""
+"145","The Land Bleeds","Mor Dhona battle",""
+"146","Primal Timbre","The Binding Coil of Bahamut","Transitions into ""Spiral"" in combat"
+"147","Calamity Unbound","The Binding Coil of Bahamut bosses",""
+"148","The Emperor's Wont","Imperial Castrums",""
+"149","Penitus","The Praetorium",""
+"150","Ultima","Ultima Weapon Phase 2",""
+"151","Steel Reason","Cape Westwind/Garlean boss fights",""
+"152","Bite of the Black Wolf","Gaius van Baelsar theme","Rise of the White Raven (199) with no vocals"
+"153","The Corpse Hall","Odin FATE",""
+"154","Thunderer","Special FATEs",""
+"155","Fallen Angel","The Howling Eye",""
+"156","Under the Weight","The Navel (Titan) phase 5",""
+"157","Weight of a Whisper","The Navel (Titan) phase 1",""
+"158","Weight of His Will ","The Navel (Titan) phase 2",""
+"159","Weight of the World","The Navel (Titan) phase 3",""
+"160","Heartless","The Navel (Titan) phase 4",""
+"161","Flight","Ultima Escape",""
+"162","The Maker's Ruin","Ultima Weapon Phase 1",""
+"163","Blinded by Light ","FFXIII crossover FATEs","Directly from FFXIII"
+"164","Saber's Edge","FFXIII crossover FATEs","Directly from FFXIII"
+"165","Torn from the Heavens","ARR Zone special FATEs/ARR Relic duties","1.0 Track"
+"166","Ruby Moonrise","Costa del Sol events","Fast ""Costa Del Sol"" music"
+"167","Serenity","The Shroud",""
+"168","On Westerly Winds","La Noscea",""
+"169","To the Sun","Thanalan",""
+"170","Crystal Rain","Mor Dhona",""
+"171","To the Fore","Heavensward dungeon boss theme","The filename seems to imply this is from a FATE"
+"172","The Rider's Boon","Generic ARR Mounts","Also the 1.0 Goobbue theme"
+"173","Thunderer","Ascian battles, Twintania",""
+"174","All Saint's Wake","Seasonal event BGM areas",""
+"175","Starlight Celebration","Seasonal event BGM areas",""
+"176","Heavensturn","Seasonal event BGM areas",""
+"177","Reign of Pain","Shantotto theme (FFXI event)",""
+"178","The Seven Jesters ","Thornmarch Phase 1",""
+"179","Good King Moggle Mog XII","Thornmarch Phase 2",""
+"180","Hubris","Labyrinth of the Ancients","Transitions into ""Ever Upwards"" in combat"
+"181","Tumbling Down","Labyrinth of the Ancients boss theme",""
+"182","Agent of Inquiry","Hildibrand episode theme",""
+"183","Frontiers Within","Revenant's Toll (day)",""
+"184","Reflections","Revenant's Toll (night)",""
+"185","A Light in the Storm ","Pharos Sirius",""
+"186","Where the Heart Is","The Mist, The Lavender Beds, The Goblet (day)",""
+"187","Where the Hearth Is","The Mist, The Lavender Beds, The Goblet (night)",""
+"188","Flibbertigibbet","East Shroud (Friendly Sylph area)",""
+"189","Smoulder","Southern Thanalan (Friendly Amalj'aa area)",""
+"190","Discordance","Cutscenes (Mysterious)","Loops. See track 57, Discordance"
+"191","Starlight and Sellswords","Aesthetician","1.0 track"
+"192","Battle Theme 1.x","Hildibrand FATEs/Hall of the Novice/B-ranks",""
+"193","Big-Boned","Fat Chocobo Theme",""
+"194","Gluppity-Schlopp","Outer La Noscea (Friendly Kobold area)",""
+"195","Breathless","Western La Noscea (Friendly Sahagin area)",""
+"196","Pa-Paya","Seasonal event BGM areas (Hatching-tide)",""
+"197","The Scars of Battle","Lost City of Amdapor",""
+"198","Tempest","The Second Coil of Bahamut (Turn 4) (Nael deus Darnus) phase 1",""
+"199","Rise of the White Raven","The Second Coil of Bahamut (Turn 4) (Nael deus Darnus) phase 2",""
+"200","Good King Moggle Mog XII","Thornmarch (Good King Moggle Mog XII) phase 2",""
+"201","Battle on the Big Bridge","Battle on the Big Bridge (Gilgamesh)",""
+"202","Blades","Second Coil/Final Coil trash music","Transitions ""Spiral"" combat"
+"203","Wreck to the Seaman","The Whorleater (Leviathan) phase 1",""
+"204","Through The Maelstrom ","The Whorleater (Leviathan) phase 2",""
+"205","Meteor","Cutscenes (Nael)",""
+"206","Persistence","ARR mid-dungeon boss theme",""
+"207","Wrath of the Eikons","The Lost City of Amdapor final boss / Dun Scaith final boss (Diabolos / Diabolos Hollow)",""
+"208","Fury","Brayflox's Longstop (Hard) boss","1.0 track"
+"209","Beneath Bloodied Banners ","Hard mode dungeon final bosses",""
+"210","Birds of a Feather","Halatali (Hard)","1.0 track"
+"211","Thicker Than a Knife's Blade","Various cutscenes, Foundation (The Forgotten Knight)",""
+"212","Now I Know the Truth","Unei and Doga theme",""
+"213","???","Seasonal event BGM areas","China lunar new year theme, needs name"
+"214","Moonfire Faire","Moonfire Faire",""
+"215","Far from Home","Ixal theme",""
+"216","Horizons Calling","Hullbreaker Isle",""
+"217","Dark Vows","Tam-Tara Deepcroft (Hard)",""
+"218","Out of the Labyrinth","The Syrcus Tower","Transitions to ""Shattered"" in combat"
+"219","The War Room","Frontlines","Gate waiting theme"
+"220","Rouse Out!","Frontlines","Transitions to ""Blood for Blood"" in combat"
+"221","Thunder Rolls ","The Striking Tree (Ramuh)",""
+"222","Game Theory","Puzzles/Minigames Theme",""
+"223","Loss of Time","Cutscenes (Crystal tower)",""
+"224","Or the Egg","Chocobo training montage",""
+"225","His Holiness","Cutscenes (Thordan)","Literally just The Dragon's Dirge"
+"226","Answers - Reprise","Ul'dah (The Rising)",""
+"227","The Corpse Hall ","Urth's Fount",""
+"228","Everbinding Oath","Eternal Bond ceremony",""
+"229","The Edge","Ninja trainer hideout",""
+"230","Footsteps in the Snow ","Akh Afah Amphitheatre (Shiva) phase 1, Eden's Verse: Refulgence (Savage) (Shiva) phase 1",""
+"231","Oblivion ","Akh Afah Amphitheatre (Shiva) phase 2",""
+"232","The Decisive Battle","The Dragon's Neck","Directly from FFVI"
+"233","The Warrens","Snowcloak",""
+"234","Forgotten by the Sun","The Sunken Temple of Qarn (Hard)",""
+"235","Riptide","Sastasha (Hard)",""
+"236","From the Ashes","The Final Coil of Bahamut (Turn 3) (Phoenix)",""
+"237","Answers","The Final Coil of Bahamut (Turn 4) (Bahamut Prime)","Harp / vocals portion"
+"238","Answers","The Final Coil of Bahamut (Turn 4) (Bahamut Prime)","Band / vocals portion"
+"239","The Coil Tightens","Cutscenes (The Binding Coil of Bahamut)",""
+"240","Answers","The Final Coil of Bahamut (Turn 4) (Bahamut Prime)","Chorus portion"
+"241","Eternal Wind","Cutscenes (Crystal tower)",""
+"242","Battle on the Big Bridge","Battle in the Big Keep Phase 1","Directly from FFV"
+"243","Silver Tears","The Keeper of the Lake",""
+"244","Primogenitor","The Keeper of the Lake final boss (Midgardsormr), Alphascape v2.0 (Midgardsormr)","Generally just Midgardsormr's theme"
+"245","Tricksome","Wanderer's Palace (Hard)",""
+"246","Aftermath","Amdapor Keep (Hard)",""
+"247","Blind to the Dark","The World of Darkness","Transitions to ""Hamartomania"" in combat"
+"248","Tumbling Down","The World of Darkness (Cerberus Stomach)","Muffled"
+"249","Hunger / The Reach of Darkness","The World of Darkness","Hunger into ""The Reach of Darkness"""
+"250","Four-Sided Circle","Manderville Gold Saucer",""
+"251","Gateway to Paradise","Chocobo racing 1",""
+"252","Sport of Kings","Chocobo racing 2",""
+"253","Shuffle or Boogie","Triple Triad","Directly from FFVIII"
+"254","Faith in Her Fury","The Steps of Faith",""
+"255","Unworthy","The Steps of Faith final gate theme",""
+"256","The Tug of Fate","The Wanderer's Palace (Hard) bosses","1.0 Hamlet defense track"
+"257","To the Fore","The Wanderer's Palace (Hard) final boss",""
+"258","Chocobo Victory 1","Chocobo racing",""
+"259","Chocobo Victory 2","Chocobo racing",""
+"260","Chocobo Victory 3","Chocobo racing",""
+"261","Drum Roll","Chocobo racing",""
+"262","Magiteknical Difficulties","Magitek Armor mount","Terra's Theme (FFVI) remix"
+"263","The Corpse Hall","Sleipnir mount",""
+"264","Oblivion","Akh Afah Amphitheatre (Extreme) (Shiva) mount",""
+"265","Thunder Rolls","The Striking Tree (Extreme) (Ramuh) mount",""
+"266","Through The Maelstorm","The Whorleater (Extreme) (Leviathan) mount",""
+"267","Under the Weight","The Navel (Extreme) (Titan) mount",""
+"268","Fallen Angel","The Howling Eye (Extreme) (Garuda) mount",""
+"269","Primal Judgement","The Bowl of Embers (Extreme) (Ifrit) mount",""
+"270","Null BGM","","Empty sound"
+"271","A Cold Wind","Heavensward title screen",""
+"272","Dragonsong","Heavensward credits",""
+"273","Shelter","Heavensward sanctuary music",""
+"274","Safety In Numbers","Heavensward sanctuary music 2",""
+"275","Nobility Obliges","The Pillars (day)",""
+"276","Nobility Sleeps","The Pillars (night)",""
+"277","Solid","The Foundation (day)",""
+"278","Night in the Brume","The Foundation (night)",""
+"279","Against the Wind ","Coerthas Western Highlands (day)",""
+"280","Black and White","Coerthas Western Highlands (night)",""
+"281","Melt","Coerthas Western Highlands combat","All ""Melt"" are the same track"
+"282","Painted Foothills","Dravanian Forelands (day)",""
+"283","Painted Skies","Dravanian Forelands (night)",""
+"284","Melt","Dravanian Forelands combat","All ""Melt"" are the same track"
+"285","Missing Pages","Dravanian Hinterlands (day)",""
+"286","The Silent Regard of Stars","Dravanian Hinterlands (night)",""
+"287","Melt","Dravanian Hinterlands combat","All ""Melt"" are the same track"
+"288","Landlords","Churning Mists (day)",""
+"289","Skylords","Churning Mists (night)",""
+"290","Melt","Churning Mists combat","All ""Melt"" are the same track"
+"291","Lost in the Clouds","Sea of Clouds (day)",""
+"292","Close to the Heavens","Sea of Clouds (night)",""
+"293","Melt","Sea of Clouds combat","All ""Melt"" are the same track"
+"294","Order Yet Undeciphered ","Azys Lla",""
+"295","Melt","Azys Lla combat","All ""Melt"" are the same track"
+"296","Paradise Found","Idyllshire (day)",""
+"297","Homestead","Idyllshire (night)",""
+"298","The Mushroomery","Matoya's Cave",""
+"299","Descent","Dusk Vigil",""
+"300","Like a Summer Rain","Neverreap",""
+"301","Slumber Eternal","Sohm Al",""
+"302","Roar of the Wyrm","The Aery",""
+"303","Ink Long Dry","Great Gubal Library ",""
+"304","Imagination ","Aetherochemical Research Facility",""
+"305","Hallowed Halls ","The Vault",""
+"306","Hallowed Halls ","The Vault","Slightly muffled"
+"307","Hallowed Halls ","The Vault","Slightly more muffled"
+"308","Unbreakable","Fractal Continuum",""
+"309","Ominous Prognisticks","Heavensward boss theme",""
+"310","The Hand That Gives The Rose","Thok ast Thok (Ravana) phase 1",""
+"311","Limitless Blue","The Limitless Blue (Bismarck) phase 1",""
+"312","Heroes","The Singularity Reactor, The Minstrel's Ballad: Thordan's Reign phase 2",""
+"313","Contention","Heavensward cutscenes, Churning Mists (Zenith)",""
+"314","Misconception","Heavensward cutscenes",""
+"315","The Heavens' Ward ","Vault final boss (Ser Charibert)",""
+"316","Stone and Steel","Heavensward cutscenes (Heroic)",""
+"317","For the Sky","Heavensward cutscenes",""
+"318","Inception","Heavensward cutscenes",""
+"319","Borderless","Default flying mount theme",""
+"320","The Dragon's Dirge","Heavensward cutscenes","This version loops"
+"321","Ultima","Proto Ultima FATE, Proto Ultima battle (Dun Scaith)",""
+"322","What is Love?","Moogle Beast Tribe",""
+"323","Sins of the Father, Sins of the Son","Alexander trash theme",""
+"324","Locus","Alexander boss theme",""
+"325","Unbending Steel","Thok ast Thok phase 2",""
+"326","Woe That Is Madness","The Limitless Blue phase 2",""
+"327","Metal","Alexander - Fist of the Father","Instrumental, vocals begin when in combat"
+"328","When a Tree Falls","FC workshop/leves","1.0 track"
+"329","","The Vault","Seems to be bells from The Vault judging by filename"
+"330","All Saint's Wake","Witch's Broom mount",""
+"331","Steel Reason","Red Baron / White Devil mounts",""
+"332","Battle Theme","The Maiden's Rhapsody (FFXI)",""
+"333","Battle Theme #2","The Maiden's Rhapsody (FFXI)",""
+"334","Recollection","The Maiden's Rhapsody (FFXI)",""
+"335","The Kingdom of San d'Oria","The Maiden's Rhapsody (FFXI)",""
+"336","The Republic of Bastok","The Maiden's Rhapsody (FFXI)",""
+"337","The Federation of Windurst","The Maiden's Rhapsody (FFXI)",""
+"338","???","","Same as 399, but the filename seems to imply this is a Hildibrand theme"
+"339","Heavy Rain","Sea of Clouds (Hostile Vanu area)",""
+"340","Coming Home","Sea of Clouds (Friendly Vanu area)",""
+"341","Heroes Never Die ","The Minstrel's Ballad: Thordan's Reign phase 1",""
+"342","Engage","The Diadem",""
+"343","Jewel","The Diadem combat",""
+"344","Torn from The Heavens","The Diadem Notorious Monster battle","Loops at the same point as 36, but is different"
+"345","Poison Ivy","Saint Mocianne's Arboretum ",""
+"346","Upon the Rocks","Pharos Sirius (Hard)",""
+"347","Aetherpause","Void Ark","Transitions to ""In Darkness, There Is One"" in combat"
+"348","Voidal Manifest","Void Ark (Echidna), The Weeping City of Mhach (Calofisteri) final bosses",""
+"349","???","Lords of Verminion","Needs name"
+"350","Brothers in Arms","Lords of Verminion","File is specific to LoV"
+"351","Nemesis","Lords of Verminion","File is specific to LoV"
+"352","The Dark's Kiss","Lords of Verminion","File is specific to LoV"
+"353","Aftermath","Lords of Verminion","File is specific to LoV"
+"354","The Corpse Hall","Lords of Verminion","File is specific to LoV"
+"355","Battle on the Big Bridge","Lords of Verminion","File is specific to LoV"
+"356","Spiral","Lords of Verminion","File is specific to LoV"
+"357","Calamity Unbound","Lords of Verminion","File is specific to LoV"
+"358","Prelude - Rebirth (2nd ver)","Kirin mount","81 that plays on Kirin"
+"359","The Kiss","Valentione's Day",""
+"360","","","Likely test or filler audio"
+"361","Down the Up Staircase","The Antitower",""
+"362","Dancing Calcabrina","The Antitower",""
+"363","No Sound, No Scutter","The Dravanian Forelands (Hostile Vath area)",""
+"364","Piece of Mind","The Dravanian Forelands (Friendly Vath area)",""
+"365","Battle to the Death - Heavensward","Containment Bay S1T7 (Sephirot) / Containment Bay P1T6 (Sophia) / Containment Bay Z1T9 (Zurvan) phase 1",""
+"366","Fiend","Containment Bay S1T7 (Sephirot) phase 2",""
+"367","Starved","The Feast",""
+"368","The Ancient City","The Lost City of Amdapor (Hard)",""
+"369","Metal - Brute Justice Mode ","Alexander - The Burden of the Son (Brute Justice) phase 2",""
+"370","","","Likely test or filler audio"
+"371","Woe That is Madness","The Limitless Blue (Extreme) (Bismarck) mount / White Lanner",""
+"372","Unbending Steel","Thok ast Thok (Extreme) (Ravana) mount / Rose Lanner",""
+"373","Heroes","The Minstrel's Ballad: Thordan's Reign (Thordan) mount / Round Lanner",""
+"374","Battle to the Death - Heavensward","Containment Bay S1T7 (Sephirot) mount / Warring Lanner",""
+"375","Tenacity","Guildhests",""
+"376","From the Ashes","Bennu mount",""
+"377","Faith in Her Fury","Heavensward cutscenes","Shorter/quick start version"
+"378","Stone and Steel","Heavensward cutscenes","Shorter/quick start version"
+"379","Primogenitor","Heavensward cutscenes","Shorter/quick start version"
+"380","Hyper Rainbow Z","Go Go Posing Rangers Theme","Also plays in PotD occasionally"
+"381","Freedom","The Parrock","A 1.0 La Noscea theme"
+"382","Dragonsong","The Final Steps of Faith (Nidhogg) / The Minstrel's Ballad: Nidhogg's Rage (Nidhogg) phase 1",""
+"383","Freefall ","The Final Steps of Faith (Nidhogg) / The Minstrel's Ballad: Nidhogg's Rage (Nidhogg) phase 2",""
+"384","Revenge of the Horde","The Final Steps of Faith (Nidhogg) / The Minstrel's Ballad: Nidhogg's Rage (Nidhogg) phase 3",""
+"385","He Who Continues the Attack","Regula van Hydrus's Theme",""
+"386","Apologies","Sohr Khai",""
+"387","Holy Consult ","Hullbreaker Isle (Hard)","1.0 track"
+"388","Bathed in Woodsin","","1.0 track"
+"389","Emerald Labyrinth","PotD","1.0 track"
+"390","Enraptured ","PotD","1.0 track"
+"391","Tears for Mor Dhona","PotD","1.0 track"
+"392","Blackbosom","PotD Floor 50 boss/Edda Blackbosom theme",""
+"393","Teardrops in the Rain","Weeping City of Mhach",""
+"394","A Thousand Faces","Weeping City of Mhach (Ozma add phase)",""
+"395","Freefall","The Minstrel's Ballad: Nidhogg's Rage (Nidhogg) mount / Dark Lanner",""
+"396","Good King Moggle Mog XXII","Fat Moogle Mount",""
+"397","Locus","Gobwalker Mount",""
+"398","Night in the Brume","Heavensward cutscenes","Variant of 278"
+"399","???","Palace of the Dead inter-floor theme","Needs name"
+"400","Fragments of Forever","Alisaie Theme","1.0 track"
+"401","Notice of Death","PotD pre-floor 100 cutscenes",""
+"402","Equilibrium ","Containment Bay P1T6 (Sophia) phase 2",""
+"403","The Gauntlet","Duel / Lost Canals of Uznair / Palace of the Dead",""
+"404","Ultima","","Quick start"
+"405","Grounded","Xelphatol",""
+"406","Revenge Twofold ","Heavensward boss theme 2",""
+"407","Bibliophobia","The Great Gubal Library (Hard)",""
+"408","Up at Dawn","The Haunted Manor (All Saint's Wake)",""
+"409","Fog of Phantom","PotD 91-100 theme",""
+"410","Blasphemous Experiment","PotD floor 100 boss theme",""
+"411","Exponential Entropy","Alexander - The Heart of the Creator (Cruise Chaser)",""
+"412","Mobius","Alexander - The Soul of the Creator (Alexander Prime) phase 1",""
+"413","Rise","Alexander - The Soul of the Creator (Alexander Prime) phase 2","Includes a channel for the time-stop music"
+"414","Out of Time","Alexander - The Soul of the Creator (Alexander Prime) timegate theme","Muffled, slow Exponential Entropy"
+"415","Equilibrium","Containment Bay P1T6 (Extreme) (Sophia) mount / Sophic Lanner",""
+"416","Mobius","Alexander - The Soul of the Creator (Savage) mount / Arrhidaeus",""
+"417","Infinity","Containment Bay Z1T9 (Zurvan) phase 3",""
+"418","test","",""
+"419","Penultimania ","Containment Bay Z1T9 / Zurvan Phase 2",""
+"420","Another Brick","Baelsar's Wall",""
+"421","Quicksand","Sohm Al (Hard)",""
+"422","Promises","Dun Scaith / Deathgaze Hollow",""
+"423","Shadow of the Body","Dun Scaith",""
+"424","Infinity","Containment Bay Z1T9 (Extreme) (Zurvan) mount / Demonic Lanner",""
+"425","Prelude - Discoveries","Firebird mount","3 that plays on Firebird"
+"426","Answers - Reprise","Ul'dah (The Rising)",""
+"427","Null BGM","","Empty sound"
+"428","Prelude - Long March Home","Stormblood title screen",""
+"429","Revolutions / A Father's Pride / The Measure of Our Reach","Stormblood credits","Revolutions excerpt into A Father's Pride into The Measure of Our Reach"
+"430","Harmony","Stormblood sanctuaries",""
+"431","With Giants Watching","Stormblood sanctuaries",""
+"432","Cradle","Stormblood sanctuaries",""
+"433","Impact","Rhalgr's Reach",""
+"434","Afterglow","Rhalgr's Reach",""
+"435","Looping in the Deepest Fringes","Gyr Abania combat","All ""Looping in the Deepest Fringes"" are the same track"
+"436","Crimson Sunrise","Kugane (day)",""
+"437","Crimson Sunset","Kugane (night)",""
+"438","Looping in the Deepest Fringes","Othard combat","All ""Looping in the Deepest Fringes"" are the same track"
+"439","Beyond The Wall","The Fringes (day)",""
+"440","Hope Forgotten","The Fringes (night)",""
+"441","Looping in the Deepest Fringes","Gyr Abania combat","All ""Looping in the Deepest Fringes"" are the same track"
+"442","On High","The Peaks (day)",""
+"443","The Stone Remembers","The Peaks (night)",""
+"444","Looping in the Deepest Fringes","Stormblood battle theme","All ""Looping in the Deepest Fringes"" are the same track"
+"445","Songs of Salt and Suffering","The Lochs (day)",""
+"446","Old Wounds","The Lochs (night)",""
+"447","Looping in the Deepest Fringes","Stormblood battle theme","All ""Looping in the Deepest Fringes"" are the same track"
+"448","Liquid Flame","The Ruby Sea (day)",""
+"449","Westward Tide","The Ruby Sea (night)",""
+"450","Looping in the Deepest Fringes","Othard combat","All ""Looping in the Deepest Fringes"" are the same track"
+"451","A Father's Pride ","Yanxia (day)",""
+"452","A Mother's Pride","Yanxia (night)",""
+"453","Looping in the Deepest Fringes","Yanxia combat","All ""Looping in the Deepest Fringes"" are the same track"
+"454","Drowning in the Horizon","The Azim Steppe (day)",""
+"455","He Rises Above","The Azim Steppe (night)",""
+"456","Looping in the Deepest Fringes","The Azim Steppe combat","All ""Looping in the Deepest Fringes"" are the same track"
+"457","Revolutions","Stormblood cutscenes","No vocals intro excerpt"
+"458","Revolutions","Stormblood cutscenes","No vocals directly post-intro excerpt"
+"459","Heroes of Stormblood","Stormblood cutscenes",""
+"460","The Measure of Our Reach","Stormblood cutscenes",""
+"461","The Measure of His Reach","Stormblood cutscenes","No vocals"
+"462","","","Likely test or filler audio"
+"463","Revolutions","Stormblood cutscenes","No vocals late-song excerpt"
+"464","Cyan's Theme","Stormblood cutscenes, The Doman Enclave",""
+"465","Far East of Eorzea","Stormblood cutscenes",""
+"466","Revelation ","The Pool of Tribute (Susano) phase 1",""
+"467","Beauty's Wicked Wiles","Emanation (Lakshmi)",""
+"468","Scale and Steel","The Royal Menagerie (Shinryu) phase 1",""
+"469","The Worm's Tail","The Royal Menagerie (Shinryu) phase 2",""
+"470","Triumph","Stormblood boss theme",""
+"471","Dawnbound","The Sirensong Sea",""
+"472","The Open Box ","The Shisui of the Violet Tides",""
+"473","Most Unworthy","Bardam's Mettle",""
+"474","Gates of the Moon","Doma Castle",""
+"475","Alienus","Castrum Abania",""
+"476","Liberty or Death ","Ala Mhigo",""
+"477","Their Deadly Mission","The Temple of the Fist",""
+"478","Deception","Kugane Castle",""
+"479","Deltascape","The Interdimensional Rift",""
+"480","Omega^2","Deltascape boss theme",""
+"481","Decisions","Deltascape v4.0 (Exdeath)","Remix of The Decisive Battle from FFV"
+"482","Final, Not Final","Deltascape v4.0 (Savage) (Neo-Exdeath)",""
+"483","Wing and a Prayer","Falcon porters",""
+"484","Wing and a Prayer","Stormblood cutscenes, Doman Enclave quests",""
+"485","Revolutions","Stormblood cutscenes","No vocals mid-song excerpt"
+"486","Prelude - Long March Home","Stormblood title screen","Quick start ver - starts 19 secs in"
+"487","Prelude - Long March Home / Measure of His Reach","Stormblood cutscenes","Slightly different 428 with more Prelude strings, transitions to ""The Measure of His Reach"""
+"488","Shell-Shocked","The Ruby Sea (Hostile Kojin area)",""
+"489","Parting Ways","Stormblood cutscenes",""
+"490","Meteor","Stormblood cutscenes (Zenos)",""
+"491","Riot ","The Pool of Tribute (Susano) phase 2",""
+"492","At Both Ends","The Pool of Tribute (Susano) phase 3",""
+"493","Riot","The Pool of Tribue (Extreme) (Susano) mount / Reveling Kamuy",""
+"494","Beauty's Wicked Wiles","Emanation (Extreme) (Lakshmi) mount / Blissful Kamuy",""
+"495","Procedamus in Peace","Rhalgr's Reach","Plays while Rhalgr's is destroyed"
+"496","Wizardly","Cheap Dungeon","Order Yet Undeciphered (294) Chiptune"
+"497","Victory","Choco Racing Victory",""
+"498","Indomitable ","Ruby Sea (Friendly Kojin area)",""
+"499","Beyond Redemption","Unending Coil of Bahamut (Ultimate) phase 4","Golden Bahamut theme"
+"500","Rival Wings","Rival Wings","Transitions to ""Birds of Prey"" in combat"
+"501","Locus","Rival Wings","Piloting Manipulator"
+"502","Exponential Entropy","Rival Wings","Piloting Cruise Chaser"
+"503","Metal - Brute Justice Mode","Rival Wings","Piloting Brute Justice"
+"504","Far From Home","The Drowned City Of Skalla",""
+"505","The Worm's Tail","The Minstrel's Ballad: Shinryu's Domain mount / Legendary Kamuy",""
+"506","Trisection","Royal City of Rabanastre",""
+"507","Precipitous Combat","Royal City of Rabanastre bosses",""
+"508","Ultima's Transformation","Royal City of Rabanastre final boss (Argath Thadulfus)",""
+"509","Victory","Royal City of Rabanastre post-final boss",""
+"510","Save / Load Screen","Return to Ivalice cutscenes",""
+"511","Character Creation","Return to Ivalice cutscenes",""
+"512","Protagonist's Theme","Return to Ivalice cutscenes",""
+"513","Stormblood alliance cutscene music","Royal City of Rabanastre","Needs name"
+"514","Background Story","Return to Ivalice cutscenes",""
+"515","The Enemy Approaches","Return to Ivalice cutscenes",""
+"516","Starlit Gateway","Seasonal event BGM areas","Starlight 2017"
+"517","Forever in Flames","","The Coil Tightens (239) shortened"
+"518","Keepers of the Lock","The Fringes (Friendly Ananta area)",""
+"519","Iroha","Reisen Temple",""
+"520","Siren Song","Seasonal event BGM areas","Little Ladies' Day"
+"521","Answer on High","The Jade Stoa (Byakko) / Hell's Kier (Suzaku) / The Wreath of Snakes (Seiryu) phase 1",""
+"522","Todoroki","The Jade Stoa (Byakko) phase 2",""
+"523","Amatsu Kaze","The Jade Stoa (Byakko) phase 3",""
+"524","Wicked Winds Whisper","Eureka Anemos, Eureka Pagos, Eureka Pyros","Transitions to (needs name) in combat"
+"525","No Quarter","Eureka Notorious Monster theme",""
+"526","Down Where Daemons Dwell","Hells' Lid",""
+"527","Unbreakable - Duality ","The Fractal Continuum (Hard)",""
+"528","The Phantom Train to Sigmascape","Sigmascape v1.0 (Phantom Train) opening cutscene",""
+"529","The Decisive Battle","Sigmascape v1.0 (Phantom Train), Sigmascape v2.0 (Demon Chadarnook), Sigmascape v3.0 (Guardian)",""
+"530","Dancing Mad - Movement I","Sigmascape v4.0 (Kefka) phase 1",""
+"531","Dancing Mad - Movement II","Sigmascape v4.0 (Kefka) phase 2",""
+"532","Dancing Mad - Movement III","Sigmascape v4.0 (Kefka) phase 3",""
+"533","Dancing Mad - Movement IV","Sigmascape v4.0 (Savage) (God Kefka)",""
+"534","Final Not Final","Deltascape v4.0 (Savage) (Neo-Exdeath) mount / Alte Roite",""
+"535","Dancing Mad IV Hushed","Sigmascape v4.0 (Savage) (God Kefka) mount / Air Force",""
+"536","Amatsu Kaze","The Jade Stoa (Extreme) (Byakko) mount / Auspicious Kamuy",""
+"537","Calling","Eureka","Same file as 56"
+"538","Pa-Paya Demastered ","Egg Hunter Riggy minigame","Easter 2018"
+"539","???","Needs location","Needs name. Allegedly Valentione's related"
+"540","Seven Hundred Seventy-Seven Whiskers","The Azim Steppe (Friendly Namazu area)",""
+"541","Nightbloom","Castrum Fluminis (Tsukuyomi) phase 1, The Minstrel's Ballad: Tsukuyomi's Pain (Tsukuyomi) phase 1",""
+"542","Lunacy","Castrum Fluminis (Tsukuyomi) phase 2, The Minstrel's Ballad: Tsukuyomi's Pain (Tsukuyomi) phase 2",""
+"543","Wayward Daughter","Castrum Fluminis (Tsukuyomi) phase 3, The Minstrel's Ballad: Tsukuyomi's Pain (Tsukuyomi) phase 3",""
+"544","Fallen Angel (From Astral to Umbral)","The Weapon's Refrain (Ultimate) phase 1",""
+"545","Primal Judgment (From Astral to Umbral)","The Weapon's Refrain (Ultimate) phase 2",""
+"546","Under the Weight (From Astral to Umbral)","The Weapon's Refrain (Ultimate) phase 3",""
+"547","Ultima (Orchestrial Version)","The Weapon's Refrain (Ultimate) phase 5",""
+"548","Savage of the Ancient Forest","The Great Hunt (Rathalos) Phase 1",""
+"549","Proof of a Hero - Monster Hunter: World version","The Great Hunt (Rathalos) Phase 2",""
+"550","Quest Complete! - Proof of a Hero version","The Great Hunt (Rathalos) post-fight",""
+"551","Earth Wind and Water","The Swallow's Compass",""
+"552","Wayward Daughter Hushed","The Minstrel's Ballad: Tsukuyomi's Pain mount / Lunar Kamuy mount",""
+"553","World Map","Needs location",""
+"554","???","Needs location","Needs name"
+"555","Ascent","Needs location","Directly from FFXII"
+"556","The Mystery of Giruvegan ","Needs location","Directly from FFXII"
+"557","Boss Theme ","Needs location","Directly from FFXII"
+"558","Apoplexy","Needs location","Directly from FFT"
+"559","Flash of Steel","Ridorana Lighthouse final boss (Yiazmat)","Directly from FFXII"
+"560","Victory","Ridorana Lighthouse final boss (Yiazmat) post-battle","Directly from FFXII"
+"561","Cornerstone of the New World - Astera","Monster Hunter: World crossover cutscenes","Day theme, 1st half of MHW OST track"
+"562","Cornerstone of the New World - Astera","Monster Hunter: World crossover cutscenes","Night theme, 2nd half of MHW OST track"
+"563","Crown of the Ancient Tree","Monster Hunter: World crossover Rathalos intro cutscene",""
+"564","Proof of a Hero - Monster Hunter: World version","The Great Hunt (Extreme) (Rathalos) Mount",""
+"565","Deception","HoH mount / Juedi",""
+"566","Crimson Sunrise","Kugane (day)","In ARR files for some reason"
+"567","Crimson Sunset","Kugane (night)","In ARR files for some reason"
+"568","Looping in the Deepest Fringes","Gyr Abania combat","All ""Looping in the Deepest Fringes"" are the same track, in ARR files for some reason"
+"569","","The Weapon's Refrain (Ultimate) phase 4",""
+"570","Wasshoi, Wasshoi!","Mikoshi mount",""
+"571","Second Council Meeting - Tension","Monster Hunter: World crossover cutscenes",""
+"572","Quest Failed","The Great Hunt (Rathalos) duty failed",""
+"573","Everywhere and Nowhere","Stormblood cutscenes (Alphascape)",""
+"574","A Dream in Flight","Stormblood cutscenes (Alphascape)",""
+"575","???","Stormblood cutscenes (Alphascape)","Needs name"
+"576","Ending","Stormblood cutscenes (Alphascape)",""
+"577","Unspoken","Cutscenes","1.0 Coerthas"
+"578","Inner Recess","Stormblood cutscenes (Omega)","1.0 track"
+"579","Neverborn","Cutscenes",""
+"580","Starlight, Starbright","Theatrhythm minigame","Transitions to ""Starlight, Not Right"" when failing the minigame"
+"581","Sunset","Hells' Kier (Suzaku) phase 2","DDR"
+"582","Sunrise","Hells' Kier (Suzaku) phase 3",""
+"583","A Land Long Dead ","The Burn",""
+"584","From Mud","Saint Mocianne's Arboretum (Hard)",""
+"585","Battle","Alphascape v1.0 (Chaos)","FF1 battle theme remix"
+"586","eScape","Alphascape v3.0 (Omega)",""
+"587","Heartless","Alphascape v4.0 (Omega M/F)",""
+"588","Sunrise","Suzaku mount",""
+"589","From the Heavens","Alphascape v4.0 (Savage) (Final Omega) mount / Omega",""
+"590","Bedlam's Brink","Solus zos Galvus theme",""
+"591","From the Heavens","Alphascape v4.0 (Savage) (Final Omega) phase 2",""
+"592","The Chase/Crazy Motorcycle","SDS Fenrir mount","Directly from FF7"
+"593","Dangertek","The Shifting of Altars of Uznair, Feast (Culling time)",""
+"594","","",""
+"595","","",""
+"596","","",""
+"597","","",""
+"598","","",""
+"599","","",""
+"600","","",""
+"601","","",""
+"602","","",""
+"603","","",""
+"604","Broken Down","Final Fantasy XV crossover cutscenes & events",""
+"605","Hammerhead","Final Fantasy XV crossover cutscenes & events","Guitar comes in at the end, not the beginning like in FFXV OST"
+"606","Valse di Fantastica","Final Fantasy XV crossover cutscenes & events",""
+"607","Relax and Reflect","Final Fantasy XV crossover cutscenes & events",""
+"608","Daemons","Final Fantasy XV crossover cutscenes & events",""
+"609","Prayer de LUNA","Final Fantasy XV crossover cutscenes & events","Slightly different from the OST"
+"610","Safe Haven","Final Fantasy XV crossover cutscenes & events",""
+"611","Veiled in Black","Final Fantasy XV crossover cutscenes & events",""
+"612","Horrors of the Night","Final Fantasy XV crossover cutscenes & events",""
+"613","Apocalypsis Noctis","Final Fantasy XV crossover cutscenes & events",""
+"614","A Quick Pit Stop","FFXV crossover mount / Regalia Type-G",""
+"615","Saint Ajora's Theme","Needs location","Directly from FFT"
+"616","Poachers' Den","Needs location","Directly from FFT"
+"617","Epilogue","Needs location","Directly from FFT"
+"618","Staff Credits","Needs location","Directly from FFT"
+"619","Brave Story","Needs location","Directly from FFT"
+"620","Alma's Theme","Needs location","Directly from FFT"
+"621","Intrigue","Needs location","Directly from FFT"
+"622","Under the Stars","Needs location","Directly from FFT"
+"623","Bloody Excrement","Needs location","Directly from FFT"
+"624","Pressure (No. 1)","Needs location","Directly from FFT"
+"625","Antipyretic","Needs location","Directly from FFT"
+"626","A Man Consumed","Orbonne Monastery (The Thunder God)","""Grotesque Creature"" from Final Fantasy Vagrant Story"
+"627","Descent","Orbonne Monastery final boss (Ultima) phase 2","Directly from FFT"
+"628","Ultima's Perfection","Orbonne Monastery final boss (Ultima) victory theme","Directly from FFT"
+"629","Final Struggle / Hall of Worship","Orbonne Monastery final boss (Ultima) victory theme","Opens with Final Struggle, transitions to Hall of Worship"
+"630","Nail of the Heavens","The Masked Carnivale","1.0 track"
+"631","Imperium","The Masked Carnivale",""
+"632","The Garden of Ru'Hmet","Baldesion Arsenal","Directly from FFXI"
+"633","Onslaught","Baldesion Arsenal boss theme","Directly from FFXI"
+"634","Turmoil","Baldesion Arsenal final boss (Proto Ozma) theme","Directly from FFXI"
+"635","From the Dragon's Wake","Seiryu mount",""
+"636","Prelude - Long March Home","Kyubi mount","No title logo slice, no flag cheering"
+"637","Horizons Calling","Nezha Chariot / Red Hare / Magicked Carpet / Sunspun Cumulus mounts",""
+"638","???","Mystic Panda / Aquamarine+Citrine+Rubellite Carbuncle / Indigo Whale / Fatter Cat / Spriggan Stonecarrier / Kingly Peacock mounts","Palace of the Dead inter-floor theme (338, 399)"
+"639","A Pall Most Murderous","The Ghimlyt Dark",""
+"640","From the Dragon's Wake","The Wreath of Snakes (Seiryu) phase 2",""
+"641","Doman Distractions","Doman Mahjong",""
+"642","Air Force One Victory","Air Force One",""
+"643","Air Force One Fail","Air Force One",""
+"644","Battle Theme 1.x","Air Force One",""
+"645","Revolutions / The Measure of Our Reach","Stormblood end credits 2",""
+"646","Shadowbringers","Shadowbringers title cutscene",""
+"647","Tomorrow and Tomorrow - Reprise","Shadowbringers cutscenes",""
+"648","A Better Tomorrow","Shadowbringers cutscenes",""
+"649","Tears in the Rain","Shadowbringers cutscenes",""
+"650","Dangerous Words","Shadowbringers cutscenes / Overworld theme","Can be overworld theme based on quest progression"
+"651","High Treason","Shadowbringers cutscenes / Overworld theme / Quest battles","Can be overworld theme based on quest progression"
+"652","More than Truth","Shadowbringers cutscenes",""
+"653","Paradisaical Predicaments","Shadowbringers cutscenes",""
+"654","Tomorrow and Tomorrow","Shadowbringers cutscenes","Reverb piano version"
+"655","Tomorrow and Tomorrow","Shadowbringers cutscenes","Reverb vocals + piano version"
+"656","Vamo' alla Flamenco","Shadowbringers cutscenes (Dancer cutscenes)",""
+"657","???","","Needs name"
+"658","The Lute","",""
+"659","The Dark Which Illuminates the World","Crystarium (day)",""
+"660","Knowledge Never Sleeps","Crystarium (night)",""
+"661","Indulgence","Eulmore (day)",""
+"662","Masquerade","Eulmore (night)",""
+"663","The Source","Lakeland (day)",""
+"664","Unchanging, Everchanging","Lakeland (night)",""
+"665","A World Divided","Kholusia (day)",""
+"666","The Quick Way","Kholusia (night)",""
+"667","Sands of Amber","Amh Araeng (day)",""
+"668","Sands of Blood","Amh Araeng (night)",""
+"669","Fierce and Free","Il Mheg (day)",""
+"670","The Faerie Ring","Il Mheg (night)",""
+"671","Civilizations","Rak'tika Greatwood (day)",""
+"672","A Hopeless Race","Rak'tika Greatwood (night)",""
+"673","Full Fathom Five","The Tempest",""
+"674","Neath Dark Waters","The Tempest (Amaurot)",""
+"675","A Reason to Live","Shadowbringers sanctuaries",""
+"676","No Greater Sorrow","Shadowbringers sanctuaries",""
+"677","Rencounter","Lakeland combat","All ""Rencounter"" are the same track"
+"678","Rencounter","Kholusia combat","All ""Rencounter"" are the same track"
+"679","Rencounter","Amh Araeng combat","All ""Rencounter"" are the same track"
+"680","Rencounter","Il Mheg combat","All ""Rencounter"" are the same track"
+"681","Rencounter","Rak'tika Greatwood combat","All ""Rencounter"" are the same track"
+"682","","The Tempest combat","Empty track, but it seems XIV needs to have zone combat themes for everything"
+"683","What Angel Wakes Me","The Dancing Plague (Titania)",""
+"684","Insanity","The Crown of the Immaculate (Innocence)",""
+"685","Who Brings Shadow","The Dying Gasp (Hades) phase 1",""
+"686","Invincible","The Dying Gasp (Hades) phase 2",""
+"687","To Fire And Sword","The Holminister Switch",""
+"688","Figments","Dohn Mheg",""
+"689","Unwound","Qitana Ravel",""
+"690","Deep Down","Malikah's Well",""
+"691","In The Belly Of The Beast","Mt. Gulg",""
+"692","Mortal Instants","Amaurot",""
+"693","Shadows Withal","Akadaemia Anyder",""
+"694","A Long Fall","The Twinning",""
+"695","Insatiable","Shadowbringers boss theme",""
+"696","Blue Fields","The Empty (unfinished)",""
+"697","Force Your Way","Eden's Gate: Resurrection (Eden Prime), Descent (Voidwalker), Eden's Verse: Iconoclasm (Idol of Darkness)",""
+"698","Landslide","Eden's Gate: Sepulture (Titan)",""
+"699","On Our Fates Alight","Amaro porter",""
+"700","What Angel Wakes Me","The Dancing Plague (Extreme) (Titania) mount / Fae Gwiber","(Mount)"
+"701","Insanity","The Crown of the Immaculate (Extreme) (Innocence) mount / Innocent Gwiber","(Mount)"
+"702","Landslide","Eden's Gate: Sepulture (Savage) (Titan) mount / Skyslipper","(Mount)"
+"703","Four-sided Circle","Sabotender Emperador mount",""
+"704","Four-fold Knowing","Shadowbringers title screen",""
+"705","Who Brings Shadow / Tomorrow and Tomorrow / Masquerade / High Treason / Knowledge Never Sleeps / The Dark Which Illuminates the World","Shadowbringers credits","Transitions directly into each song"
+"706","Locus (The Primals)","The Twinning, The Epic of Alexander (Ultimate) phase 1",""
+"707","Tomorrow and Tomorrow","Shadowbringers cutscenes","Part 1 of full track"
+"708","Tomorrow and Tomorrow","Shadowbringers cutscenes","Part 2 of full track"
+"709","Tomorrow and Tomorrow","Shadowbringers cutscenes","No vocals"
+"710","Shattered","","2nd channel of 218, Syrcus Tower combat music"
+"711","Pain in Pleasure","Eulmore","A 2nd Eulmore day theme"
+"712","Such as it Is","Shadowbringers sanctuaries",""
+"713","Null BGM","","Empty sound"
+"714","The Darks' Kiss","","2nd channel of 17, ARR Hard dungeon combat music"
+"715","On Our Fates Alight","Amaro mount",""
+"716","Unmatching Pieces","Kholusia","Alt theme (Everlasting light?)"
+"717","Blinding Indigo","Eden's Gate: Inundation (Leviathan)",""
+"718","Starlight, De Chocobo","Theatrhythm minigame","Transitions to an unnamed off-key version when failing the minigame"
+"719","The Garden's Gates","Lyhe Mheg",""
+"720","The Mendicant's Relish","The Firmament",""
+"721","Siren Song","Eulmore (The Beehive)",""
+"722","A Fine Air Forbiddeth","Onsal Hakair","Transitions to ""A Fierce Air Forceth"" in combat"
+"723","Metal - Brute Justice Mode (The Primals)","The Epic of Alexander (Ultimate) phase 2",""
+"724","","The Epic of Alexander (Ultimate) phase 2 to 3","The timestop here is not in another channel because it does not have to sync with Rise"
+"725","Rise (The Primals)","The Epic of Alexander (Ultimate) phase 3",""
+"726","Moebius (Orchestral Version)","The Epic of Alexander (Ultimate) phase 4",""
+"727","The Grand Cosmos","The Grand Cosmos",""
+"728","Invincible","The Minstrel's Ballad: Hades' Elegy mount / Shadow Gwiber",""
+"729","A Fierce Air Forceth","Construct VII mount",""
+"730","Starved","Epimetheus, Menoetius mounts",""
+"731","Imperium","Morbol mount",""
+"732","Significance - Nothing","The Copied Factory solo exploration",""
+"733","City Ruins - Rays of Light","The Copied Factory - Nier Automata OST",""
+"734","Vague Hope","The Copied Factory - (Quest Area)",""
+"735","","",""
+"736","Voice of No Return","Need location","From FFXIV x NieR crossover"
+"737","Alien Manifestation","The Copied Factory","From FFXIV x NieR crossover"
+"738","Song of the Ancients - Atonement","The Copied Factory boss 1 (Serial-jointed Command Model) and 2 (Hobbes)","From FFXIV x NieR crossover"
+"739","Bipolar Nightmare","The Copied Factory boss 3 (Engels)","From FFXIV x NieR crossover"
+"740","Weight of the World - Prelude Version ","The Copied Factory boss 4 (9S-operated Walking Fortress)","From FFXIV x NieR crossover"
+"741","Crumbling Lies","Need location","From FFXIV x NieR crossover"
+"742","Where I Belong","Eden cutscenes / The Empty (finished)","FFVIII"
+"743","Hopl's Dropple","Rak'tika Greatwood (Friendly Qitari area)",""
+"744","???","Gangos","Needs name"
+"745","Pa-Paya Demastered ","Egg Hunter Riggy minigame","Easter 2020"
+"746","Ultima (The Primals)","Cinder Drift (The Ruby Weapon) phase 1",""
+"747","???","The Firmament","Needs name"
+"748","Insatiable (The Primals)","Shadowbringers mid-dungeon bosses",""
+"749","Floundering in the Depths","Anamnesis Anyder",""
+"750","Twice Stricken","Eden's Verse: Fulmination (Ramuh)",""
+"751","Primal Angel","Eden's Verse: Furor (Garuda & Ifrit, Raktapaksa)",""
+"752","Return to Oblivion","Eden's Verse: Refulgence (Shiva) phase 1",""
+"753","Ultima (The Primals)","The Cinder Drift (Extreme) mount / Ruby Gwiber",""
+"754","Twice Stricken","Eden's Verse: Fulmination (Savage) (Ramuh) mount / Ramuh",""
+"755","Rise of The White Raven","The Cinder Drift (2nd Phase)","This version has far more prominent vocals"
+"756","Horizons Calling","Ocean Fishing",""
+"757","Holy Consult","Ocean Fishing",""
+"758","When a Tree Falls","Ocean Fishing",""
+"759","Oblivion's Refusal","Eden's Verse: Refulgence (Shiva) add phase",""
+"760","Eternal Wind - Shadowbringers","",""
+"761","???","","Shorter alt version of Shadowbringers, needs name"
+"762","Tomorrow and Tomorrow","","Full song"
+"763","???","Shadowbringers cutscenes","Needs name"
+"764","???","Shadowbringers cutscenes","Needs name"
+"765","Moonfire Faire Event","Eastern La Noscea Moonfire Faire",""
+"766","Watts's Anvil","Lakeland (Friendly Dwarf area)",""
+"767","And Love You Shall Find","Terncliff",""
+"768","To The Edge","The Seat of Sacrifice phase 1, The Seat of Sacrifice (Extreme)",""
+"769","","The Seat of Sacrifice","Active time maneuver mid-normal mode"
+"770","","",""
+"771","To The Edge","The Seat of Sacrifice",""
+"772","Wind on the Plains","The Bozjan Southern Front","Transitions to ""Blood on the Wind"" in combat"
+"773","Discord: Imperial (Zodiac Age Version)","The Bozjan Southern Front (certain critical engagements)",""
+"774","Into the Fortress (Zodiac Age Version)","The Bozjan Southern Front (Castrum Lacus Litore)",""
+"775","Battle with an Esper (Zodiac Age Version)","The Bozjan Southern Front (Castrum Lacus Litore boss theme)",""
+"776","Life and Death (Zodiac Age Version)","The Bozjan Southern Front (Castrum Lacus Litore final boss (Dawon & Lyon))",""
+"777","Where All Roads Lead","The Heroes Gauntlet",""
+"778","To The Edge","The Seat of Sacrifice (Extreme) mount / Gwiber of Light",""
+"779","Discord: Imperial (Zodiac Age Version)","The Bozjan Southern Front lockbox mount / Gabriel Î±",""
+"780","Broken Heart","Needs location","From FFXIV x NieR crossover"
+"781","City Ruins (Rays of Light) (Instrumental)","Needs location","From FFXIV x NieR crossover"
+"782","Amusement Park","Needs location","From FFXIV x NieR crossover"
+"783","Fortress of Lies","Needs location","From FFXIV x NieR crossover"
+"784","Grandma - Destruction","Needs location","From FFXIV x NieR crossover"
+"785","End of the Unknown","Needs location","From FFXIV x NieR crossover"
+"786","Torn From the Heavens/The Dark Colossus Destroys All (Medley)","The Puppet's Bunker final boss (Compound 2P)","From FFXIV x NieR crossover"
+"787","Unrest (Zodiac Age Version)","The Bozjan Southern Front",""
+"788","","The Firmament mount / Pteradon",""
+"789","Heavensward","City of Giants (Solo Instance)",""
+"790","Nightbloom","City of Giants (Solo Instance)",""
+"791","","",""
+"792","The Black Wolf Stalks Again","Castrum Marinum (Emerald Weapon) phase 2",""
+"793","","",""
+"794","","",""
+"795","","",""
+"796","","",""
+"797","Shuffle or Boogie","Triple Triad tournaments",""
+"798","Freshly Baked Porxie","Matoya's Relict",""
+"799","Don't Be Afraid","Eden's Promise: Umbra (Cloud of Darkness), Eden's Promise: Litany (Shadowkeeper)",""
+"800","The Legendary Beast","Eden's Promise: Anamorphosis (Fatebreaker)",""
+"801","Promises to Keep","Eden's Promise: Eternity (Eden's Promise)",""
+"802","The Extreme","Eden's Promise: Eternity (Savage) (Oracle of Darkness)",""
+"803","The Black Wolf Stalks Again","Castrum Marinum (Extreme) (Emerald Weapon) / Emerald Gwiber",""
+"804","Promises to Keep (Mount)","Eden's Promise: Eternity (Savage) mount / Eden",""
+"805","","",""
+"806","???","Eden's Promise: Eternity phase 2","Needs name"

--- a/OrchestrionPlugin/OrchestrionPlugin.csproj
+++ b/OrchestrionPlugin/OrchestrionPlugin.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OrchestrionPlugin/Plugin.cs
+++ b/OrchestrionPlugin/Plugin.cs
@@ -18,6 +18,7 @@ namespace OrchestrionPlugin
     public class Plugin : IDalamudPlugin, IPlaybackController, IResourceLoader
     {
         public string Name => "Orchestrion plugin";
+        public string AssemblyLocation { get; set; } = Assembly.GetExecutingAssembly().Location;
 
         private const string songListFile = "xiv_bgm.csv";
         private const string commandName = "/porch";
@@ -38,7 +39,7 @@ namespace OrchestrionPlugin
             this.configuration.Initialize(pluginInterface);
             this.enableFallbackPlayer = this.configuration.UseOldPlayback;
 
-            this.localDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            this.localDir = Path.GetDirectoryName(AssemblyLocation);
 
             var songlistPath = Path.Combine(this.localDir, songListFile);
             this.songList = new SongList(songlistPath, this.configuration, this, this);

--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ Those numbers are the internal ids used by the game.  Many numbers do not corres
 ### It's so hard to find certain tracks!  Can you add/change/remove (some specific info)?
 In short, no.
 
-All the song information in the player is taken from [this spreadsheet](https://docs.google.com/spreadsheets/d/14yjTMHYmuB1m5-aJO8CkMferRT9sNzgasYq02oJENWs/edit#gid=0), which I do not maintain.
+All the song information in the player is taken from [this spreadsheet](https://docs.google.com/spreadsheets/d/1gGNCu85sjd-4CDgqw-K5tefTe4HYuDK38LkRyvx_fEc), which I do not maintain.
 
-You might be able to ask in the CMTool discord if there is information you think should be added etc, as it is (was?) maintained from there.  But I am not involved in that process.
+This sheet is not maintained by me, but feel free to comment in the document if you find any inconsistencies.
 
 ### Some new in-game music is out and I can't find it!
-If the tracks are new, it is possible that either the spreadsheet has not been updated by the community yet, or that I have not pulled in the latest updates to it.
+If the tracks are new, it is possible that either the spreadsheet has not been updated by the community yet.
 
 ### I have a suggestion/issue/concern!
 Mention it in the XL discord, or create an issue here.
 
 ## Credits
 * goat, for the launcher and dalamud, without which none of this would be possible.
-* MagowDeath#1763 for maintaining [the community spreadsheet](https://docs.google.com/spreadsheets/d/14yjTMHYmuB1m5-aJO8CkMferRT9sNzgasYq02oJENWs/edit#gid=0) with all of the song data that is used in this plugin.
+* MagowDeath#1763 for maintaining [the previous spreadsheet](https://docs.google.com/spreadsheets/d/14yjTMHYmuB1m5-aJO8CkMferRT9sNzgasYq02oJENWs/edit#gid=0) with all of the song data that is used in this plugin.
 * Many thanks to [Caraxi](https://github.com/Caraxi/) for keeping things working and updated while I was away!
 * Too many discord people to name, for helping out with things and offering suggestions.


### PR DESCRIPTION
Resolves #2 with automatic BGM updating. The sheet it uses as a source is located [here](https://docs.google.com/spreadsheets/d/1gGNCu85sjd-4CDgqw-K5tefTe4HYuDK38LkRyvx_fEc) and will be maintained by myself. I've already fixed a lot of song names, locations, and resolved incorrect song names. I am usually available and get comments sent straight to my e-mail so I'd like to think I will update it swiftly.

Because Title Edit uses this sheet with the same updating system, I thought why not PR to the **actual** BGM plugin. On startup, the sheet is fetched in csv form from the above Google sheet, parsed, and saved as the new csv file if it parses correctly. The included csv has been modified to be parseable by the same code, as a backup.

The third column in the sheet is for additional comments or information about a track, so that has been added to the interface on a new line and is also searchable.
![Screenshot_10566](https://user-images.githubusercontent.com/6005409/104116158-2f07e600-52e4-11eb-9135-872798e205ac.png)

The only issues here are that in pursuit of full documentation, some songs display badly:
![Screenshot_10564](https://user-images.githubusercontent.com/6005409/104116242-c79e6600-52e4-11eb-94f9-b9cbd5715d43.png)
when the window is expanded:
![Screenshot_10565](https://user-images.githubusercontent.com/6005409/104116245-d38a2800-52e4-11eb-941f-7f8207e9fe98.png)

I don't see this as much of an issue, but I can attempt to find a better solution if you'd like, assuming you like this idea in general. Thanks for reading.

(As a side note, the plugin is also now compatible with the LivePluginLoader)